### PR TITLE
Fix GPU options

### DIFF
--- a/brc_jupyter-compute/form.js
+++ b/brc_jupyter-compute/form.js
@@ -113,7 +113,7 @@ function set_slurm_partition_change_handler() {
   let slurm_partition = $("#batch_connect_session_context_slurm_partition");
   slurm_partition.change(() => {
     toggle_gres_value_field_visibility();
-    toggle_cpu_cores_field_visibility();
+    // toggle_cpu_cores_field_visibility();
     toggle_slurm_account_qos_fields_visibility();
     update_available_options();
   });
@@ -145,7 +145,7 @@ $(document).ready(function() {
   set_available_partitions();
   // Ensure that fields are shown or hidden based on what was set in the last session
   toggle_gres_value_field_visibility();
-  toggle_cpu_cores_field_visibility();
+  // toggle_cpu_cores_field_visibility();
   toggle_slurm_account_qos_fields_visibility();
   // Update available options appropriately
   update_available_options();

--- a/brc_jupyter-compute/form.yml.erb
+++ b/brc_jupyter-compute/form.yml.erb
@@ -29,7 +29,6 @@ form:
   - slurm_account
   - qos_name
   - num_nodes
-  - num_cores
   - gres_value
   - bc_num_hours
   - user_email
@@ -60,7 +59,7 @@ attributes:
 
   qos_name:
     label: "SLURM QoS Name"
-    help: "Most users can leave it black for default assignment, Savio Condo users want to specify their condo QoS name"
+    help: "Most users can leave it blank for default assignment, Savio Condo users want to specify their condo QoS name"
     widget: select
 
   num_nodes:
@@ -68,14 +67,9 @@ attributes:
     help: "Please specify the number of nodes you want for this Jupyter Server"
     value: 1
 
-  num_cores:
-    label: "Number of CPU cores per Node"
-    help: "Please specify the number of CPU cores you want per node for this Jupyter Server"
-    value: 1
-
   gres_value:
-    label: "Number and type of GPUs"
-    help: "You choose to run in a partition with GPUs. Please specify the GRES value i.e the number and type of GPUs you want for this Jupyter Server"
+    label: "Number of GPUs"
+    help: "You choose to run in a partition with GPUs. Please specify the number and type of GPUs you want for this Jupyter Server."
 
   user_email:
     label: "Email address (optional)"

--- a/brc_jupyter-compute/submit.yml.erb
+++ b/brc_jupyter-compute/submit.yml.erb
@@ -51,11 +51,9 @@ script:
      <%- end %>
      <%- if gres_value != "" %>
      - "--gres"
-     - "<%= gres_value %>"
-     <%- end %>
-     <%- if num_cores != "" %>
-     - "--ntasks-per-core"
-     - "<%= num_cores %>"
+     - "gpu:<%= gres_value %>"
+     - "--cpus-per-task"
+     - "<%= gres_value.to_i() * 2 %>"
      <%- end %>
      - "--nodes"
      - "<%= num_nodes %>"


### PR DESCRIPTION
- Remove manual option for CPUs (was previously `--ntasks-per-core`)
- Automatically set `--cpus-per-task` to 2 times the number of GPUs
- Request user to enter only number of GPUs. For example, `2` instead of `gpu:2`