### PR TITLE
set default num gpus for matlab to 0

### DIFF
--- a/brc_matlab/form.yml.erb
+++ b/brc_matlab/form.yml.erb
@@ -101,7 +101,7 @@ attributes:
   num_gpus:
     widget: "number_field"
     label: "Number of GPUs if a GPU partition is requested"
-    value: 1
+    value: 0
     min: 0
     max: 8
     step: 1


### PR DESCRIPTION
Not sure why the default is 1; presumably an oversight.