### PR TITLE
WIP: various rewordings of the app forms

### DIFF
--- a/brc_jupyter-compute/form.yml.erb
+++ b/brc_jupyter-compute/form.yml.erb
@@ -71,7 +71,7 @@ attributes:
 
   num_cores:
     label: "Number of CPU Cores per Node"
-    help: "The number of CPU cores you want per node for your Jupyter sesson."
+    help: "The number of CPU cores you want per node for your Jupyter session."
     value: 1
 
   gres_value:

--- a/brc_jupyter-compute/form.yml.erb
+++ b/brc_jupyter-compute/form.yml.erb
@@ -41,44 +41,45 @@ attributes:
 
   bc_num_hours:
     label: "Wall Clock Time"
-    help: "How many hours do you want to run this Jupyter Server for?"
+    help: "The maximum number of hours your Jupyter session will run for. To save FCA credits or free up resources for your condo group members, you should delete your session when you are done."
     value: 1
 
   job_name:
-    label: "Name of the job"
-    value: "OOD_batch"
+    label: "Name of the Job"
+    value: "OOD_Jupyter"
 
   slurm_partition:
     label: "SLURM Partition"
-    help: "Choose the name of the SLURM Partition in which you want to launch this Jupyter Server"
+    help: "The SLURM Partition in which you want to launch this Jupyter session."
     widget: select
     required: true
 
   slurm_account:
-    label: "SLURM Project/Account Name"
+    label: "SLURM Account/Project Name"
+    help: "The SLURM account (i.e., the value of the -A or --account flag used when submitting a SLURM job)."
     widget: select
 
   qos_name:
     label: "SLURM QoS Name"
-    help: "Please choose the specific QoS you want run under. Most users choose savio_normal. Savio Condo users want to specify their condo QoS name or savio_lowprio"
+    help: "The QoS you want run under. Most FCA users choose savio_normal. Condo users can either use their condo QoS or the low-priority QoS."
     widget: select
 
   num_nodes:
-    label: "Number of Nodes"
-    help: "Please specify the number of nodes you want for this Jupyter Server"
+    label: "Number of Compute Nodes"
+    help: "The number of nodes you want for your Jupyter session."
     value: 1
 
   num_cores:
-    label: "Number of CPU cores per Node"
-    help: "Please specify the number of CPU cores you want per node for this Jupyter Server"
+    label: "Number of CPU Cores per Node"
+    help: "The number of CPU cores you want per node for your Jupyter sesson."
     value: 1
 
   gres_value:
-    label: "Number and type of GPUs"
-    help: "You choose to run in a partition with GPUs. Please specify the GRES value i.e the number and type of GPUs you want for this Jupyter Server"
+    label: "Number and Type of GPUs"
+    help: "The GRES value in the form 'gpu:x' or 'gpu:type:x' where 'x' is the number of GPUs and (optionally) 'type' is the type of GPU. Remember to specify two CPUs for each GPU in the 'Number of CPU Cores per Node' field."
 
   user_email:
-    label: "Email address (optional)"
+    label: "Email Address (Optional)"
     help: "Enter your email address if you would like to receive an email when the session starts. Leave blank for no email."
 
   raw_data:

--- a/brc_jupyter-compute/manifest.yml
+++ b/brc_jupyter-compute/manifest.yml
@@ -1,10 +1,10 @@
 ---
-name: Jupyter Server - compute in batch queues
+name: Jupyter Server - compute via Slurm using Savio partitions
 category: Interactive Apps
 subcategory: Servers
 role: batch_connect
 description: |
-  This app will launch a [Jupyter] server using [Python] on the [UCB] [Research-IT] Berkeley Research Computing([BRC]) Infrastructure clusters.
+  This app will launch a [Jupyter] server session on the Berkeley Research Computing([BRC]) Savio cluster.
 
   [Jupyter]: https://jupyter.org/
   [Python]: https://www.python.org/

--- a/brc_jupyter-lha/form.yml
+++ b/brc_jupyter-lha/form.yml
@@ -17,5 +17,5 @@ attributes:
 
   bc_num_hours:
     label: "Wall Clock Time"
-    help: "How many hours do you want to run this Jupyter Server for ? (At this time Jupyter Servers launched in this mode are limited to 1 cpu core and 2GB of memory, If you want more CPU/MEM or GPU resources please choose to launch Jupyter Server via compute app in the batch queues)"
+    help: "The maximum number of hours your Jupyter session will run for."
     value: 1

--- a/brc_jupyter-lha/manifest.yml
+++ b/brc_jupyter-lha/manifest.yml
@@ -1,10 +1,10 @@
 ---
-name: Jupyter Server - nonbatch for exploration, debugging
+name: Jupyter Server - compute on shared Jupyter node for exploration, debugging
 category: Interactive Apps
 subcategory: Servers
 role: batch_connect
 description: |
-  This app will launch a [Jupyter] server using [Python] on the [UCB] [Research-IT] Berkeley Research Computing([BRC]) Infrastructure. Use this app to launch notebooks for light weight, short duration, interactive exploration and debugging of code and data. For heavy, long and compute intensive needs please use the another Jupyter Server app to run in the batch queues of the clusters.
+  This app will launch a [Jupyter] server session on a shared Jupyter node on the Berkeley Research Computing([BRC]) infrastructure. Use this app to launch notebooks for lightweight, short duration, interactive exploration and debugging of code and data (using a single CPU core and at most 2 GB memory). For long or compute-intensive jobs, please use the other Jupyter Server app to run in the compute partitions of the Savio cluster. 
 
   [Jupyter]: https://jupyter.org/
   [Python]: https://www.python.org/

--- a/brc_matlab/form.yml
+++ b/brc_matlab/form.yml
@@ -19,13 +19,13 @@ attributes:
   node_type: "CPU"
   
   job_name:
-    label: "Name of the job"
-    value: "OOD_MatLab_"
+    label: "Name of the Job"
+    value: "OOD_MATLAB"
 
   versions:
     widget: select
-    label: "MATLAB Versions"
-    help: "This defines the version of MATLAB to load."
+    label: "MATLAB Version"
+    help: "The version of MATLAB used."
     options:
       - [ "R2020b", "matlab/r2020b" ]
       - [ "R2020a", "matlab/r2020a" ]
@@ -36,7 +36,7 @@ attributes:
   slurm_partition: 
     widget: "select"
     label: "SLURM Partition"
-    help: "Choose the name of the SLURM Partition in which you want to launch this MatLab Server"
+    help: "The SLURM Partition in which you want to launch your MATLAB session."
     options:
       - [ "savio", "savio" ]
       - [ "savio2", "savio2" ]
@@ -51,21 +51,21 @@ attributes:
     required: true
 
   bc_account:
-    label: "SLURM Project/Account Name"
-    help: "You can't leave this blank."
+    label: "SLURM Account/Project Name"
+    help: "The SLURM account (i.e., the value of the -A or --account flag used when submitting a SLURM job)."
 
   qos_name:
     label: "SLURM QoS Name"
-    help: "Please choose the specific QoS you want run under. Most users choose savio_normal. Savio Condo users want to specify their condo QoS name or savio_lowprio"
+    help: "The QoS you want run under. Most FCA users choose savio_normal. Condo users can either use their condo QoS or the low-priority QoS."
  
   bc_num_slots:
-    label: "Number of CPU Nodes"
-    help: "Please specify number of CPU nodes"
+    label: "Number of Compute Nodes"
+    help: "The number of nodes you want for your MATLAB session."
     value: 1
     max: 10
     step: 1
 
   bc_num_hours:
     label: "Wall Clock Time"
-    help: "How many hours do you want to run this MatLab?"
+    help: "The maximum number of hours your MATLAB session will run for. To save FCA credits or free up resources for your condo group members, you should delete your session when you are done."
     value: 1

--- a/brc_matlab/form.yml.erb
+++ b/brc_matlab/form.yml.erb
@@ -41,13 +41,13 @@ attributes:
   node_type: "CPU"
 
   job_name:
-    label: "Name of the job"
-    value: "OOD_MatLab_"
+    label: "Name of the Job"
+    value: "OOD_MATLAB"
 
   versions:
     widget: select
     label: "MATLAB Versions"
-    help: "This defines the version of MATLAB to load."
+    help: "The version of MATLAB used."
     options:
       - [ "R2020b", "matlab/r2020b" ]
       - [ "R2020a", "matlab/r2020a" ]
@@ -58,44 +58,45 @@ attributes:
 
   bc_num_hours:
     label: "Wall Clock Time"
-    help: "How many hours do you want to run Matlab" 
+    help: "The maximum number of hours your MATLAB session will run for. To save FCA credits or free up resources for your condo group members, you should delete your session when you are done."
     value: 1
 
   job_name:
-    label: "Name of the job"
-    value: "OOD_batch"
+    label: "Name of the Job"
+    value: "OOD_MATLAB"
 
   slurm_partition:
     label: "SLURM Partition"
-    help: "Choose the name of the SLURM Partition in which you want to launch MatLab" 
+    help: "The SLURM Partition in which you want to launch your MATLAB session."
     widget: select
     required: true
 
   slurm_account:
     label: "SLURM Project/Account Name"
+    help: "The SLURM account (i.e., the value of the -A or --account flag used when submitting a SLURM job)."
     widget: select
 
   qos_name:
     label: "SLURM QoS Name"
-    help: "Please choose the specific QoS you want run under. Most users choose savio_normal. Savio Condo users want to specify their condo QoS name or savio_lowprio"
+    help: "The QoS you want run under. Most FCA users choose savio_normal. Condo users can either use their condo QoS or the low-priority QoS."
     widget: select
 
   num_nodes:
-    label: "Number of Nodes"
-    help: "Please specify the number of nodes you want for Matlab" 
+    label: "Number of Compute Nodes"
+    help: "The number of nodes you want for your MATLAB session."
     value: 1
 
   num_cores:
-    label: "Number of CPU cores per Node"
-    help: "Please specify the number of CPU cores you want per node for MatLab" 
+    label: "Number of CPU Cores per Node"
+    help: "The number of CPU cores you want per node for your MATLAB session."
     value: 1
 
   gres_value:
-    label: "Number and type of GPUs"
-    help: "You choose to run in a partition with GPUs. Please specify the GRES value i.e the number and type of GPUs you like to use"
+    label: "Number and Type of GPUs"
+    help: "The GRES value in the form 'gpu:x' or 'gpu:type:x' where 'x' is the number of GPUs and (optionally) 'type' is the type of GPU. Remember to specify two CPUs for each GPU in the 'Number of CPU Cores per Node' field."
   
   user_email:
-    label: "Email address (optional)"
+    label: "Email Address (Optional)"
     help: "Enter your email address if you would like to receive an email when the session starts. Leave blank for no email."
 
   raw_data:

--- a/brc_matlab/manifest.yml
+++ b/brc_matlab/manifest.yml
@@ -4,7 +4,7 @@ category: Interactive Apps
 subcategory: GUIs
 role: batch_connect
 description: |
-  This app will launch a [MATLAB] GUI on the [UCB] [Research-IT] Berkeley Research Computing([BRC]) Infrastructure clusters. You will be able to interact with the MATLAB GUI through a VNC session
+  This app will launch a [MATLAB] Desktop session within a VNC session on the Berkeley Research Computing([BRC]) Savio cluster. 
   [MATLAB]: https://www.mathworks.com/products/matlab.html
   [UCB]: https://www.berkeley.edu/
   [Research-IT]: https://research-it.berkeley.edu/

--- a/brc_rstudio-compute/form.yml.erb
+++ b/brc_rstudio-compute/form.yml.erb
@@ -38,44 +38,45 @@ attributes:
 
   bc_num_hours:
     label: "Wall Clock Time"
-    help: "How many hours do you want to run this Rstudio Server for ?"
+    help: "The maximum number of hours your RStudio session will run for. To save FCA credits or free up resources for your condo group members, you should delete your session when you are done."
     value: 1
 
   job_name:
-    label: "Name of the job"
-    value: "OOD_batch"
+    label: "Name of the Job"
+    value: "OOD_RStudio"
 
   slurm_partition:
     label: "SLURM Partition"
-    help: "Choose the name of the SLURM Partition in which you want to launch this Rstudio Server"
+    help: "The SLURM Partition in which you want to launch your RStudio session."
     widget: select
     required: true
 
   slurm_account:
-    label: "SLURM Project/Account Name"
+    label: "SLURM Account/Project Name"
+    help: "The SLURM account (i.e., the value of the -A or --account flag used when submitting a SLURM job)."
     widget: select
 
   qos_name:
     label: "SLURM QoS Name"
-    help: "Please choose the specific QoS you want run under. Most users choose savio_normal. Savio Condo users want to specify their condo QoS name or savio_lowprio"
+    help: "The QoS you want run under. Most FCA users choose savio_normal. Condo users can either use their condo QoS or the low-priority QoS."
     widget: select
 
   num_nodes:
-    label: "Number of Nodes"
-    help: "Please specify the number of nodes you want for this Rstudio Server"
+    label: "Number of Compute Nodes"
+    help: "The number of nodes you want for your RStudio session."
     value: 1
 
   num_cores:
-    label: "Number of CPU cores per Node"
-    help: "Please specify the number of CPU cores you want per node for this Rstudio Server"
+    label: "Number of CPU Cores per Node"
+    help: "The number of CPU cores you want per node for your Rstudio sesson."
     value: 1
 
   gres_value:
-    label: "Number and type of GPUs"
-    help: "You choose to run in a partition with GPUs. Please specify the GRES value i.e the number and type of GPUs you want for this Rstudio Server"
+    label: "Number and Type of GPUs"
+    help: "The GRES value in the form 'gpu:x' or 'gpu:type:x' where 'x' is the number of GPUs and (optionally) 'type' is the type of GPU. Remember to specify two CPUs for each GPU in the 'Number of CPU Cores per Node' field."
 
   user_email:
-    label: "Email address (optional)"
+    label: "Email Address (Optional)"
     help: "Enter your email address if you would like to receive an email when the session starts. Leave blank for no email."
 
   raw_data:

--- a/brc_rstudio-compute/form.yml.erb
+++ b/brc_rstudio-compute/form.yml.erb
@@ -68,7 +68,7 @@ attributes:
 
   num_cores:
     label: "Number of CPU Cores per Node"
-    help: "The number of CPU cores you want per node for your RStudio sesson."
+    help: "The number of CPU cores you want per node for your RStudio session."
     value: 1
 
   gres_value:

--- a/brc_rstudio-compute/form.yml.erb
+++ b/brc_rstudio-compute/form.yml.erb
@@ -68,7 +68,7 @@ attributes:
 
   num_cores:
     label: "Number of CPU Cores per Node"
-    help: "The number of CPU cores you want per node for your Rstudio sesson."
+    help: "The number of CPU cores you want per node for your RStudio sesson."
     value: 1
 
   gres_value:

--- a/brc_rstudio-compute/manifest.yml
+++ b/brc_rstudio-compute/manifest.yml
@@ -1,10 +1,10 @@
 ---
-name: RStudio Server - compute in batch queues
+name: RStudio Server - compute via Slurm using Savio partitions
 category: Interactive Apps
 subcategory: Servers
 role: batch_connect
 description: |
-  This app will launch a [RStudio Server] an IDE for [R] on the [UCB] [Research-IT] Berkeley Research Computing([BRC]) Infrastructure clusters.
+  This app will launch an [RStudio] (an IDE for [R]) session on the Berkeley Research Computing([BRC]) Savio cluster.
 
   [RStudio Server]: https://www.rstudio.com/products/rstudio-server/
   [R]: https://www.r-project.org/

--- a/brc_vscodeserver/form.yml
+++ b/brc_vscodeserver/form.yml
@@ -13,5 +13,5 @@ attributes:
 
   bc_num_hours:
     label: "Wall Clock Time"
-    help: "How many hours do you want to run this VS Code Server for ?"
+    help: "The maximum number of hours your VS Code Server will run for."
     value: 1

--- a/brc_vscodeserver/manifest.yml
+++ b/brc_vscodeserver/manifest.yml
@@ -4,7 +4,7 @@ category: Interactive Apps
 subcategory: Servers
 role: batch_connect
 description: |
-  This app will launch a [VS Code] server using [Code Server] on the [UCB] [Research-IT] Berkeley Research Computing ([BRC]) Infrastructure. 
+  This app will launch a [VS Code] server using [Code Server] on the Berkeley Research Computing ([BRC]) infrastructure. 
 
   [VS Code]: https://code.visualstudio.com
   [Code Server]: https://github.com/cdr/code-server


### PR DESCRIPTION
I've made a bunch of edits to the wording of the forms. I've tried to make the language and grammar consistent across fields and the different apps. 

I also reworded the labeling of the apps to refer to 'Savio partitions' rather than 'batch queues'.  'queue' is an overloaded term (e.g. QoS) and in our docs we don't use the word 'batch' (and 'sbatch' is non-interactive while these OOD sessions are interactive). I think it will be more clear the way I worded it, but others may have other opinions.

@wfeinstein @kmuriki please take a look in general.

Also, I think we should remove the need for the user to specify "gpu" in the GPU field. It looks like we can auto-populate that in `submit.yml.erb` so that in the simplest case the user can simply specify the number of GPUs and in the more complicated case they can specify, e.g., "TITAN:1". 

I can add that change to this PR, but let me know if that's not a good idea.