### PR TITLE
Set max time for savio_debug to one hour

### DIFF
--- a/brc_jupyter-compute/form.js
+++ b/brc_jupyter-compute/form.js
@@ -100,9 +100,20 @@ function set_available_qos() {
   replace_options($("#batch_connect_session_context_qos_name"), qos);
 }
 
+function set_max_time() {
+  const selected_qos = $("#batch_connect_session_context_qos_name").val();
+  if (selected_qos === "savio_debug") {
+    $("#batch_connect_session_context_bc_num_hours").attr("max", 1);
+  } else {
+    $("#batch_connect_session_context_bc_num_hours").attr("max", "");
+  }
+}
+
+
 function update_available_options() {
   set_available_accounts();
   set_available_qos();
+  set_max_time();  
 }
 
 
@@ -115,6 +126,16 @@ function set_slurm_partition_change_handler() {
     toggle_gres_value_field_visibility();
     toggle_cpu_cores_field_visibility();
     toggle_slurm_account_qos_fields_visibility();
+    update_available_options();
+  });
+}
+
+/**
+ * Sets the change handler for the slurm qos select.
+ */
+function set_slurm_qos_change_handler() {
+  let slurm_qos = $("#batch_connect_session_context_qos_name");
+  slurm_qos.change(() => {
     update_available_options();
   });
 }
@@ -151,5 +172,6 @@ $(document).ready(function() {
   update_available_options();
 
   set_slurm_partition_change_handler();
+  set_slurm_qos_change_handler();
   set_slurm_account_change_handler();
 });

--- a/brc_matlab/form.js
+++ b/brc_matlab/form.js
@@ -100,9 +100,19 @@ function set_available_qos() {
   replace_options($("#batch_connect_session_context_qos_name"), qos);
 }
 
+function set_max_time() {
+  const selected_qos = $("#batch_connect_session_context_qos_name").val();
+  if (selected_qos === "savio_debug") {
+    $("#batch_connect_session_context_bc_num_hours").attr("max", 1);
+  } else {
+    $("#batch_connect_session_context_bc_num_hours").attr("max", "");
+  }
+}
+
 function update_available_options() {
   set_available_accounts();
   set_available_qos();
+  set_max_time();  
 }
 
 
@@ -118,6 +128,17 @@ function set_slurm_partition_change_handler() {
     update_available_options();
   });
 }
+
+/**
+ * Sets the change handler for the slurm qos select.
+ */
+function set_slurm_qos_change_handler() {
+  let slurm_qos = $("#batch_connect_session_context_qos_name");
+  slurm_qos.change(() => {
+    update_available_options();
+  });
+}
+
 
 /**
  * Sets the change handler for the slurm account select.
@@ -151,6 +172,7 @@ $(document).ready(function() {
   update_available_options();
 
   set_slurm_partition_change_handler();
+  set_slurm_qos_change_handler();
   set_slurm_account_change_handler();
 });
 

--- a/brc_rstudio-compute/form.js
+++ b/brc_rstudio-compute/form.js
@@ -109,8 +109,6 @@ function set_max_time() {
   }
 }
 
-//const mx = $("#batch_connect_session_context_bc_num_hours").attr("max");
-
 function update_available_options() {
   set_available_accounts();
   set_available_qos();

--- a/brc_rstudio-compute/form.js
+++ b/brc_rstudio-compute/form.js
@@ -100,9 +100,21 @@ function set_available_qos() {
   replace_options($("#batch_connect_session_context_qos_name"), qos);
 }
 
+function set_max_time() {
+  const selected_qos = $("#batch_connect_session_context_qos_name").val();
+  if (selected_qos === "savio_debug") {
+    $("#batch_connect_session_context_bc_num_hours").attr("max", 1);
+  } else {
+    $("#batch_connect_session_context_bc_num_hours").attr("max", "");
+  }
+}
+
+//const mx = $("#batch_connect_session_context_bc_num_hours").attr("max");
+
 function update_available_options() {
   set_available_accounts();
   set_available_qos();
+  set_max_time();  
 }
 
 
@@ -115,6 +127,16 @@ function set_slurm_partition_change_handler() {
     toggle_gres_value_field_visibility();
     toggle_cpu_cores_field_visibility();
     toggle_slurm_account_qos_fields_visibility();
+    update_available_options();
+  });
+}
+
+/**
+ * Sets the change handler for the slurm qos select.
+ */
+function set_slurm_qos_change_handler() {
+  let slurm_qos = $("#batch_connect_session_context_qos_name");
+  slurm_qos.change(() => {
     update_available_options();
   });
 }
@@ -151,5 +173,6 @@ $(document).ready(function() {
   update_available_options();
 
   set_slurm_partition_change_handler();
+  set_slurm_qos_change_handler();
   set_slurm_account_change_handler();
 });


### PR DESCRIPTION
I was concerned about users submitting OOD session requests that ask for more than one hour on savio_debug (which is easy to do, since savio_debug is the default) and then not knowing why their OOD session didn't work (and generating help tickets/frustration).

This PR modifies `form.js` so that the max number of hours is responsive to QoS selection.
