### PR TITLE
Minor form updates

### DIFF
--- a/brc_desktop/form.yml.erb
+++ b/brc_desktop/form.yml.erb
@@ -38,35 +38,37 @@ attributes:
   node_type: "CPU"
   
   job_name:
-    label: "Name of the job"
-    value: "   "
+    label: "Name of the Job"
+    value: "OOD_Desktop"
 
   bc_num_hours:
     label: "Wall Clock Time"
-    help: "How many hours do you want to run desktop"
+    help: "The maximum number of hours your Desktop session will run for."
     value: 1
 
   slurm_partition: 
-    label: "Partition"
+    label: "SLURM Partition"
+    help: "The SLURM partition in which you want to launch this Desktop session. Only savio2_htc is available at this time."
     widget: select
 
   slurm_account:
-    label: "SLURM Project/Account Name"
+    label: "SLURM Account/Project Name"
+    help: "The SLURM account (i.e., the value of the -A or --account flag used when submitting a SLURM job)."
     widget: select
 
   qos_name:
     label: "SLURM QoS Name"
-    help: "Please choose the specific QoS you want run under. Most users choose savio_normal. Savio Condo users want to specify their condo QoS name or savio_lowprio"
+    help: "The QoS you want run under. Most FCA users choose savio_normal. Condo users can either use their condo QoS or the low-priority QoS."
     widget: select
 
   num_cores:
-    label: "Number of CPU cores (max=12)"
-    help: "Please specify the number of CPU cores needed to launch your desktop application"
+    label: "Number of CPU Cores"
+    help: "The number of CPU cores you want for your Desktop session (max=12)."
     value: 1
     max: 12
 
   user_email:
-    label: "Email address (optional)"
+    label: "Email Address (optional)"
     help: "Enter your email address if you would like to receive an email when the session starts. Leave blank for no email."
 
   raw_data:

--- a/brc_desktop/manifest.yml
+++ b/brc_desktop/manifest.yml
@@ -5,6 +5,6 @@ category: Interactive Apps
 subcategory: Desktops
 role: batch_connect
 description: |
-  This app will launch an interactive desktop on the Berkeley Research Computing([Research-IT]) at UC Berkeley ([BRC]) Savio cluster. You can launch GUI applications once your desktop is ready.
+  This app will launch an interactive desktop on the Berkeley Research Computing([BRC]) Savio cluster. You can launch GUI applications once your desktop is ready.
   [Research-IT]: https://research-it.berkeley.edu/
   [BRC]: https://research-it.berkeley.edu/programs/berkeley-research-computing

--- a/brc_jupyter-compute/form.yml.erb
+++ b/brc_jupyter-compute/form.yml.erb
@@ -50,7 +50,7 @@ attributes:
 
   slurm_partition:
     label: "SLURM Partition"
-    help: "The SLURM Partition in which you want to launch this Jupyter session."
+    help: "The SLURM Partition in which you want to launch this Jupyter session. For code that is not parallelized (or using only a small number of CPU cores), the HTC partitions are a good choice."
     widget: select
     required: true
 

--- a/brc_jupyter-compute/manifest.yml
+++ b/brc_jupyter-compute/manifest.yml
@@ -4,7 +4,7 @@ category: Interactive Apps
 subcategory: Servers
 role: batch_connect
 description: |
-  This app will launch a [Jupyter] server session on the Berkeley Research Computing([BRC]) Savio cluster.
+  This app will launch a [Jupyter] server session on the Berkeley Research Computing ([BRC]) Savio cluster.
 
   [Jupyter]: https://jupyter.org/
   [Python]: https://www.python.org/

--- a/brc_jupyter-lha/manifest.yml
+++ b/brc_jupyter-lha/manifest.yml
@@ -4,7 +4,7 @@ category: Interactive Apps
 subcategory: Servers
 role: batch_connect
 description: |
-  This app will launch a [Jupyter] server session on a shared Jupyter node on the Berkeley Research Computing([BRC]) infrastructure. Use this app to launch notebooks for lightweight, short duration, interactive exploration and debugging of code and data (using a single CPU core and at most 2 GB memory). For long or compute-intensive jobs, please use the other Jupyter Server app to run in the compute partitions of the Savio cluster. 
+  This app will launch a [Jupyter] server session on a shared Jupyter node on the Berkeley Research Computing ([BRC]) infrastructure. Use this app to launch notebooks for lightweight, short duration, interactive exploration and debugging of code and data (using a single CPU core and at most 8 GB memory). For long or compute-intensive jobs, please use the other Jupyter Server app to run in the compute partitions of the Savio cluster. 
 
   [Jupyter]: https://jupyter.org/
   [Python]: https://www.python.org/

--- a/brc_jupyter-lha/manifest.yml
+++ b/brc_jupyter-lha/manifest.yml
@@ -4,7 +4,7 @@ category: Interactive Apps
 subcategory: Servers
 role: batch_connect
 description: |
-  This app will launch a [Jupyter] server session on a shared Jupyter node on the Berkeley Research Computing ([BRC]) infrastructure. Use this app to launch notebooks for lightweight, short duration, interactive exploration and debugging of code and data (using a single CPU core and at most 8 GB memory). For long or compute-intensive jobs, please use the other Jupyter Server app to run in the compute partitions of the Savio cluster. 
+  This app will launch a [Jupyter] server session on a shared Jupyter node on the Berkeley Research Computing ([BRC]) infrastructure. Use this app to launch notebooks for lightweight, short duration, interactive exploration and debugging of code and data (using a small number of cores and at most 8 GB memory). For long or compute-intensive jobs, please use the other Jupyter Server app to run in the compute partitions of the Savio cluster. 
 
   [Jupyter]: https://jupyter.org/
   [Python]: https://www.python.org/

--- a/brc_matlab/form.yml.erb
+++ b/brc_matlab/form.yml.erb
@@ -67,7 +67,7 @@ attributes:
 
   slurm_partition:
     label: "SLURM Partition"
-    help: "The SLURM Partition in which you want to launch your MATLAB session."
+    help: "The SLURM Partition in which you want to launch your MATLAB session. For code that is not parallelized (or using only a small number of CPU cores), the HTC partitions are a good choice."
     widget: select
     required: true
 

--- a/brc_rstudio-compute/form.yml.erb
+++ b/brc_rstudio-compute/form.yml.erb
@@ -55,7 +55,7 @@ attributes:
 
   slurm_partition:
     label: "SLURM Partition"
-    help: "The SLURM Partition in which you want to launch your RStudio session. For R code that will not run in parallel, savio2_htc is a good choice."
+    help: "The SLURM Partition in which you want to launch your RStudio session. For code that is not parallelized (or using only a small number of CPU cores), the HTC partitions are a good choice."
     widget: select
     required: true
 

--- a/brc_rstudio-lha/manifest.yml
+++ b/brc_rstudio-lha/manifest.yml
@@ -4,7 +4,7 @@ category: Interactive Apps
 subcategory: Servers
 role: batch_connect
 description: |
-  This app will launch an [RStudio] (an IDE for [R]) session on a shared OOD node on the Berkeley Research Computing ([BRC]) infrastructure. Use this app to launch RStudio sessions for lightweight, short duration, interactive exploration and debugging of code and data (using a single CPU core and at most 8 GB memory). For long or compute-intensive jobs, please use the other RStudio Server app to run in the compute partitions of the Savio cluster. 
+  This app will launch an [RStudio] (an IDE for [R]) session on a shared OOD node on the Berkeley Research Computing ([BRC]) infrastructure. Use this app to launch RStudio sessions for lightweight, short duration, interactive exploration and debugging of code and data (using a small number of cores and at most 8 GB memory). For long or compute-intensive jobs, please use the other RStudio Server app to run in the compute partitions of the Savio cluster. 
 
   [RStudio]: https://www.rstudio.com/products/rstudio/
   [R]: https://www.r-project.org/

--- a/brc_rstudio-lha/manifest.yml
+++ b/brc_rstudio-lha/manifest.yml
@@ -4,7 +4,7 @@ category: Interactive Apps
 subcategory: Servers
 role: batch_connect
 description: |
-  This app will launch an [RStudio] (an IDE for [R]) session on a shared OOD node on the Berkeley Research Computing ([BRC]) infrastructure. Use this app to launch RStudio sessions for lightweight, short duration, interactive exploration and debugging of code and data (using a single CPU core and at most 2 GB memory). For long or compute-intensive jobs, please use the other RStudio Server app to run in the compute partitions of the Savio cluster. 
+  This app will launch an [RStudio] (an IDE for [R]) session on a shared OOD node on the Berkeley Research Computing ([BRC]) infrastructure. Use this app to launch RStudio sessions for lightweight, short duration, interactive exploration and debugging of code and data (using a single CPU core and at most 8 GB memory). For long or compute-intensive jobs, please use the other RStudio Server app to run in the compute partitions of the Savio cluster. 
 
   [RStudio]: https://www.rstudio.com/products/rstudio/
   [R]: https://www.r-project.org/


### PR DESCRIPTION
@tin6150 This changes the forms to indicate 8 GB rather than 2 GB (issue #21) and suggests users consider HTC partitions for Slurm-based apps (Jupyter, MATLAB, RStudio) since many users are likely not to be doing much parallel processing in their interactive coding. 