### PR TITLE
Update RStudio app for R 4.2.1

### DIFF
--- a/brc_rstudio-compute/README.md
+++ b/brc_rstudio-compute/README.md
@@ -17,13 +17,16 @@ This provides an RStudio Server app tailored for BRC that uses the system R (and
 
 These comments indicate what needs to be done for the Savio RStudio app relative to the template provided in the [MCW app](https://github.com/mcw-rcc/bc_rcc_rstudio_server).
 
-1. Install RStudio Server in a module, as shown in the consultsw module farm, at `scripts/rstudio-server/1.3.1093`. Note that just dumps the binaries from the rpm onto the filesystem. As of version 1.4 (I think) RStudio Server needs dynamically links to a Postgres library, libpq, which is not available on Savio, but for now the older RStudio Server should be fine.
-2. Make sure that `template/bin/auth` uses `-lt` as discussed [here](https://discourse.osc.edu/t/rstudio-server-app-using-non-local-r/1223/3).
-3. Modify `form.yml.erb` to build on existing Savio RStudio OOD config to reflect the Savio Slurm config. Set variables for the versions of RStudio Server, R, and R-spatial.
+1. Install RStudio Server in a module, as shown in the consultsw module farm, at `scripts/rstudio-server/2022.07.2-576`. Note that just dumps the binaries from the rpm onto the filesystem. 
+2. As of version 1.4 (I think) RStudio Server needs to dynamically link to a Postgres library, libpq (64-bit version). The HPCS team installs this in `/global/software/sl-7.x86_64/modules/langs/r/${R_VERSION}/postgres-lib64`.
+3. Modify `template/script.sh.erb` as needed for `rserver` and `rsession` processes to start. For `2022.07.2-576` we need to set `--auth-none 1` (to avoid RStudio prompting user to provide username/password), `-database-config-file "${DBCONF}"` (and associated stanza earlier to set `${DBCONF}`) and `--server-user $(whoami)` (so `rserver` doesn't try to run as non-existent `rstudio-server` user.
 4. Modify `template/script.sh.erb` to load modules and set R library search path details.
+5. Make sure that `template/bin/auth` uses `-lt` as discussed [here](https://discourse.osc.edu/t/rstudio-server-app-using-non-local-r/1223/3).
+6. Modify `form.yml.erb` to build on existing Savio RStudio OOD config to reflect the Savio Slurm config. Set variables for the versions of RStudio Server, R, and R-spatial.
+
 
 # Todo
 
 - Set up the widget so users can choose the version of R they want. We'll need to dynamically determine which version of r-spatial to use and what the user's `R_LIBS_USER` should be, i.e., `~/R/x86_64-pc-linux-gnu-library/<RVERSION>`.
-- Consider making the default partition `savio2_htc` given most (many?) users wil not be doing parallel computations. The widget options seem to come from some global OOD config, so not sure if this is possible to override for a single app.
+- Consider making the default partition `savio3_htc` given most (many?) users wil not be doing parallel computations. The widget options seem to come from some global OOD config, so not sure if this is possible to override for a single app.
 

--- a/brc_rstudio-compute/form.js
+++ b/brc_rstudio-compute/form.js
@@ -57,7 +57,7 @@ function toggle_gres_value_field_visibility() {
 function toggle_cpu_cores_field_visibility() {
   let slurm_partition = $("#batch_connect_session_context_slurm_partition");
   let per_core_partitions = [
-    'savio2_gpu', 'savio2_1080ti', 'savio3_gpu', 'savio2_htc', 'savio2_knl', 'savio3_htc', 'savio3_2080ti'
+      'savio2_gpu', 'savio2_1080ti', 'savio3_gpu', 'savio2_htc', 'savio2_knl', 'savio3_htc', 'savio3_2080ti', 'savio4_htc'
   ];
 
   toggle_visibility_of_form_group(

--- a/brc_rstudio-compute/form.yml.erb
+++ b/brc_rstudio-compute/form.yml.erb
@@ -39,10 +39,10 @@ form:
   - raw_data
 
 attributes:
-  Rserver: "rstudio-server/1.3.1093"
-  Rapp: "r/4.0.3"
-  Rspatial: "r-spatial/2021-02-05-r40"
-  R_major_version: "4.0"
+  Rserver: "rstudio-server/2022.07.2-576"
+  Rapp: "r/4.2.1"
+  Rspatial: "r-spatial/4.2"
+  R_major_version: "4.2"
 
   bc_num_hours:
     label: "Wall Clock Time"

--- a/brc_rstudio-compute/manifest.yml
+++ b/brc_rstudio-compute/manifest.yml
@@ -4,7 +4,7 @@ category: Interactive Apps
 subcategory: Servers
 role: batch_connect
 description: |
-  This app will launch an [RStudio] (an IDE for [R]) session on the Berkeley Research Computing([BRC]) Savio cluster.
+  This app will launch an [RStudio] (an IDE for [R]) session on the Berkeley Research Computing([BRC]) Savio cluster, using R 4.2.1.
 
   [RStudio]: https://www.rstudio.com/products/rstudio/
   [R]: https://www.r-project.org/

--- a/brc_rstudio-compute/template/script.sh.erb
+++ b/brc_rstudio-compute/template/script.sh.erb
@@ -2,11 +2,12 @@
 
 module purge
 
+# load R (before RStudio as RStudio module needs ${R_DIR} set)
+module load <%= context.Rapp %>  
+
 # load RStudio Server
 module load <%= context.Rserver %>  
 
-# load R
-module load <%= context.Rapp %>  
 
 # Free RStudio Server does not support use of R_LIBS_SITE:
 # https://community.rstudio.com/t/rstudio-server-pro-and-r-libs-site-works-but-not-on-the-free-version-not-supported/83514
@@ -47,6 +48,18 @@ EOL
 )
 chmod 700 "${RSESSION_WRAPPER_FILE}"
 
+# Generate a database.conf file
+export DBCONF="${PWD}/database.conf"
+(
+umask 077
+sed 's/^ \{2\}//' > "${DBCONF}" << EOL
+  # set database location
+  provider=sqlite
+  directory=/tmp/rstudio-server/db
+EOL
+)
+chmod 700 "${DBCONF}"
+
 # Set working directory to home directory
 cd "${HOME}"
 
@@ -61,9 +74,11 @@ echo "Starting up rserver..."
 set -x
 rserver \
   --www-port ${port} \
-  --auth-none 0 \
+  --auth-none 1 \
   --auth-pam-helper-path "${RSTUDIO_AUTH}" \
   --auth-encrypt-password 0 \
   --rsession-path "${RSESSION_WRAPPER_FILE}" \
   --server-data-dir "${TMPDIR}" \
-  --secure-cookie-key-file "${TMPDIR}/rstudio-server/secure-cookie-key"
+  --secure-cookie-key-file "${TMPDIR}/rstudio-server/secure-cookie-key" \
+  --database-config-file "${DBCONF}" \
+  --server-user $(whoami) 

--- a/brc_rstudio-compute/template/script.sh.erb
+++ b/brc_rstudio-compute/template/script.sh.erb
@@ -3,16 +3,16 @@
 module purge
 
 # load RStudio Server
-module load <%= context.Rserver %>  # rstudio-server/1.3.1093
+module load <%= context.Rserver %>  
 
 # load R
-module load <%= context.Rapp %>  # r/4.0.3
+module load <%= context.Rapp %>  
 
 # Free RStudio Server does not support use of R_LIBS_SITE:
 # https://community.rstudio.com/t/rstudio-server-pro-and-r-libs-site-works-but-not-on-the-free-version-not-supported/83514
 # but when we run rsession below, we can hack it in via --r-libs-user, in addition to R_LIBS_USER
 module load r-packages
-module load <%= context.Rspatial %>   # r-spatial/2021-02-05-r40
+module load <%= context.Rspatial %>   
 
 # R_LIBS_USER will generally be empty
 if [ "$R_LIBS_USER" = "" ]; then

--- a/brc_rstudio-lha/README.md
+++ b/brc_rstudio-lha/README.md
@@ -16,10 +16,12 @@ This provides an RStudio Server app tailored for BRC that uses the system R (and
 
 These comments indicate what needs to be done for the Savio RStudio app relative to the template provided in the [MCW app](https://github.com/mcw-rcc/bc_rcc_rstudio_server).
 
-1. Install RStudio Server in a module, as shown in the consultsw module farm, at `scripts/rstudio-server/1.3.1093`. Note that just dumps the binaries from the rpm onto the filesystem. As of version 1.4 (I think) RStudio Server needs dynamically links to a Postgres library, libpq, which is not available on Savio, but for now the older RStudio Server should be fine.
-2. Make sure that `template/bin/auth` uses `-lt` as discussed [here](https://discourse.osc.edu/t/rstudio-server-app-using-non-local-r/1223/3).
-3. Modify `form.yml` to build on existing Savio RStudio OOD config. Set variables for the versions of RStudio Server, R, and R-spatial.
+1. Install RStudio Server in a module, as shown in the consultsw module farm, at `scripts/rstudio-server/2022.07.2-576`. Note that just dumps the binaries from the rpm onto the filesystem. 
+2. As of version 1.4 (I think) RStudio Server needs to dynamically link to a Postgres library, libpq (64-bit version). The HPCS team installs this in `/global/software/sl-7.x86_64/modules/langs/r/${R_VERSION}/postgres-lib64`.
+3. Modify `template/script.sh.erb` as needed for `rserver` and `rsession` processes to start. For `2022.07.2-576` we need to set `--auth-none 1` (to avoid RStudio prompting user to provide username/password), `-database-config-file "${DBCONF}"` (and associated stanza earlier to set `${DBCONF}`) and `--server-user $(whoami)` (so `rserver` doesn't try to run as non-existent `rstudio-server` user.
 4. Modify `template/script.sh.erb` to load modules and set R library search path details.
+5. Make sure that `template/bin/auth` uses `-lt` as discussed [here](https://discourse.osc.edu/t/rstudio-server-app-using-non-local-r/1223/3).
+6. Modify `form.yml.erb` to build on existing Savio RStudio OOD config to reflect the Savio config. Set variables for the versions of RStudio Server, R, and R-spatial.
 
 # Todo
 

--- a/brc_rstudio-lha/form.yml
+++ b/brc_rstudio-lha/form.yml
@@ -14,10 +14,10 @@ form:
   - bc_num_hours
 
 attributes:
-  Rserver: "rstudio-server/1.3.1093"
-  Rapp: "r/4.0.3"
-  Rspatial: "r-spatial/2021-02-05-r40"
-  R_major_version: "4.0"
+  Rserver: "rstudio-server/2022.07.2-576"
+  Rapp: "r/4.2.1"
+  Rspatial: "r-spatial/4.2"
+  R_major_version: "4.2"
 
   bc_num_hours:
     label: "Wall Clock Time"

--- a/brc_rstudio-lha/manifest.yml
+++ b/brc_rstudio-lha/manifest.yml
@@ -4,7 +4,7 @@ category: Interactive Apps
 subcategory: Servers
 role: batch_connect
 description: |
-  This app will launch an [RStudio] (an IDE for [R]) session on a shared OOD node on the Berkeley Research Computing ([BRC]) infrastructure. Use this app to launch RStudio sessions for lightweight, short duration, interactive exploration and debugging of code and data (using a small number of cores and at most 8 GB memory). For long or compute-intensive jobs, please use the other RStudio Server app to run in the compute partitions of the Savio cluster. 
+  This app will launch an [RStudio] (an IDE for [R]) session on a shared OOD node on the Berkeley Research Computing ([BRC]) Savio cluster, using R 4.2.1. Use this app to launch RStudio sessions for lightweight, short duration, interactive exploration and debugging of code and data (using a small number of cores and at most 8 GB memory). For long or compute-intensive jobs, please use the other RStudio Server app to run in the compute partitions of the Savio cluster. 
 
   [RStudio]: https://www.rstudio.com/products/rstudio/
   [R]: https://www.r-project.org/

--- a/brc_rstudio-lha/template/script.sh.erb
+++ b/brc_rstudio-lha/template/script.sh.erb
@@ -3,10 +3,10 @@
 module purge
 
 # load RStudio Server
-module load <%= context.Rserver %>  # rstudio-server/1.3.1093
+module load <%= context.Rserver %> 
 
 # load R
-module load <%= context.Rapp %>  # r/4.0.3
+module load <%= context.Rapp %>  
 
 # Free RStudio Server does not support use of R_LIBS_SITE:
 # https://community.rstudio.com/t/rstudio-server-pro-and-r-libs-site-works-but-not-on-the-free-version-not-supported/83514
@@ -47,6 +47,18 @@ EOL
 )
 chmod 700 "${RSESSION_WRAPPER_FILE}"
 
+# Generate a database.conf file
+export DBCONF="${PWD}/database.conf"
+(
+umask 077
+sed 's/^ \{2\}//' > "${DBCONF}" << EOL
+  # set database location
+  provider=sqlite
+  directory=/tmp/rstudio-server/db
+EOL
+)
+chmod 700 "${DBCONF}"
+
 # Set working directory to home directory
 cd "${HOME}"
 
@@ -63,11 +75,14 @@ echo "Starting up rserver..."
 set -x
 rserver \
   --www-port ${port} \
-  --auth-none 0 \
+  --auth-none 1 \
   --auth-pam-helper-path "${RSTUDIO_AUTH}" \
   --auth-encrypt-password 0 \
   --rsession-path "${RSESSION_WRAPPER_FILE}" \
-  --server-data-dir $TMPDIR \
-  --secure-cookie-key-file "$TMPDIR/rstudio-server/secure-cookie-key" 
+  --server-data-dir "${TMPDIR}" \
+  --secure-cookie-key-file "${TMPDIR}/rstudio-server/secure-cookie-key" \
+  --database-config-file "${DBCONF}" \
+  --server-user $(whoami) 
+
 
 


### PR DESCRIPTION
@wfeinstein @tin6150 This updates to the latest version of RStudio and uses the latest (4.2.1) version of R.
A few changes were needed in how `template/script.sh.erb` invokes `rserver` given changes in rstudio-server.

If you'd be able to approve this and merge it in in the next week or so, that would be helpful, given we have the new version of R now available and there are users who'd like to use RStudio with the new R.