### PR TITLE
fix issue with /tmp/rstudio-server/db 

### DIFF
--- a/brc_rstudio-compute/README.md
+++ b/brc_rstudio-compute/README.md
@@ -19,7 +19,7 @@ These comments indicate what needs to be done for the Savio RStudio app relative
 
 1. Install RStudio Server in a module, as shown in the consultsw module farm, at `scripts/rstudio-server/2022.07.2-576`. Note that just dumps the binaries from the rpm onto the filesystem. 
 2. As of version 1.4 (I think) RStudio Server needs to dynamically link to a Postgres library, libpq (64-bit version). The HPCS team installs this in `/global/software/sl-7.x86_64/modules/langs/r/${R_VERSION}/postgres-lib64`.
-3. Modify `template/script.sh.erb` as needed for `rserver` and `rsession` processes to start. For `2022.07.2-576` we need to set `--auth-none 1` (to avoid RStudio prompting user to provide username/password), `-database-config-file "${DBCONF}"` (and associated stanza earlier to set `${DBCONF}`) and `--server-user $(whoami)` (so `rserver` doesn't try to run as non-existent `rstudio-server` user.
+3. Modify `template/script.sh.erb` as needed for `rserver` and `rsession` processes to start. As of `2022.07.2-576` we need to set `--auth-none 1` (to avoid RStudio prompting user to provide username/password), `-database-config-file "${DBCONF}"` (and associated stanza earlier to set `${DBCONF}`) and `--server-user $(whoami)` (so `rserver` doesn't try to run as non-existent `rstudio-server` user.
 4. Modify `template/script.sh.erb` to load modules and set R library search path details.
 5. Make sure that `template/bin/auth` uses `-lt` as discussed [here](https://discourse.osc.edu/t/rstudio-server-app-using-non-local-r/1223/3).
 6. Modify `form.yml.erb` to build on existing Savio RStudio OOD config to reflect the Savio Slurm config. Set variables for the versions of RStudio Server, R, and R-spatial.

--- a/brc_rstudio-compute/form.yml.erb
+++ b/brc_rstudio-compute/form.yml.erb
@@ -39,7 +39,7 @@ form:
   - raw_data
 
 attributes:
-  Rserver: "rstudio-server/2022.07.2-576"
+  Rserver: "rstudio-server/2022.12.0-353"
   Rapp: "r/4.2.1"
   Rspatial: "r-spatial/4.2"
   R_major_version: "4.2"

--- a/brc_rstudio-lha/README.md
+++ b/brc_rstudio-lha/README.md
@@ -16,9 +16,9 @@ This provides an RStudio Server app tailored for BRC that uses the system R (and
 
 These comments indicate what needs to be done for the Savio RStudio app relative to the template provided in the [MCW app](https://github.com/mcw-rcc/bc_rcc_rstudio_server).
 
-1. Install RStudio Server in a module, as shown in the consultsw module farm, at `scripts/rstudio-server/2022.07.2-576`. Note that just dumps the binaries from the rpm onto the filesystem. 
+1. Install RStudio Server in a module, as shown in the consultsw module farm, at `scripts/rstudio-server/2022.12.0-353`. Note that just dumps the binaries from the rpm onto the filesystem. 
 2. As of version 1.4 (I think) RStudio Server needs to dynamically link to a Postgres library, libpq (64-bit version). The HPCS team installs this in `/global/software/sl-7.x86_64/modules/langs/r/${R_VERSION}/postgres-lib64`.
-3. Modify `template/script.sh.erb` as needed for `rserver` and `rsession` processes to start. For `2022.07.2-576` we need to set `--auth-none 1` (to avoid RStudio prompting user to provide username/password), `-database-config-file "${DBCONF}"` (and associated stanza earlier to set `${DBCONF}`) and `--server-user $(whoami)` (so `rserver` doesn't try to run as non-existent `rstudio-server` user.
+3. Modify `template/script.sh.erb` as needed for `rserver` and `rsession` processes to start. For `2022.12.0-353` we need to set `--auth-none 1` (to avoid RStudio prompting user to provide username/password), `-database-config-file "${DBCONF}"` (and associated stanza earlier to set `${DBCONF}`) and `--server-user $(whoami)` (so `rserver` doesn't try to run as non-existent `rstudio-server` user.
 4. Modify `template/script.sh.erb` to load modules and set R library search path details.
 5. Make sure that `template/bin/auth` uses `-lt` as discussed [here](https://discourse.osc.edu/t/rstudio-server-app-using-non-local-r/1223/3).
 6. Modify `form.yml.erb` to build on existing Savio RStudio OOD config to reflect the Savio config. Set variables for the versions of RStudio Server, R, and R-spatial.

--- a/brc_rstudio-lha/README.md
+++ b/brc_rstudio-lha/README.md
@@ -18,10 +18,12 @@ These comments indicate what needs to be done for the Savio RStudio app relative
 
 1. Install RStudio Server in a module, as shown in the consultsw module farm, at `scripts/rstudio-server/2022.12.0-353`. Note that just dumps the binaries from the rpm onto the filesystem. 
 2. As of version 1.4 (I think) RStudio Server needs to dynamically link to a Postgres library, libpq (64-bit version). The HPCS team installs this in `/global/software/sl-7.x86_64/modules/langs/r/${R_VERSION}/postgres-lib64`.
-3. Modify `template/script.sh.erb` as needed for `rserver` and `rsession` processes to start. For `2022.12.0-353` we need to set `--auth-none 1` (to avoid RStudio prompting user to provide username/password), `-database-config-file "${DBCONF}"` (and associated stanza earlier to set `${DBCONF}`) and `--server-user $(whoami)` (so `rserver` doesn't try to run as non-existent `rstudio-server` user.
+3. Modify `template/script.sh.erb` as needed for `rserver` and `rsession` processes to start. As of `2022.07.2-576` we need to set `--auth-none 1` (to avoid RStudio prompting user to provide username/password), `-database-config-file "${DBCONF}"` (and associated stanza earlier to set `${DBCONF}`) and `--server-user $(whoami)` (so `rserver` doesn't try to run as non-existent `rstudio-server` user.
 4. Modify `template/script.sh.erb` to load modules and set R library search path details.
 5. Make sure that `template/bin/auth` uses `-lt` as discussed [here](https://discourse.osc.edu/t/rstudio-server-app-using-non-local-r/1223/3).
 6. Modify `form.yml.erb` to build on existing Savio RStudio OOD config to reflect the Savio config. Set variables for the versions of RStudio Server, R, and R-spatial.
+
+Note that RStudio Server creates `~/.cache/rstudio/session-rpc-key` at some point. I'm not clear on whether this is session-specific.
 
 # Todo
 

--- a/brc_rstudio-lha/form.yml
+++ b/brc_rstudio-lha/form.yml
@@ -14,7 +14,7 @@ form:
   - bc_num_hours
 
 attributes:
-  Rserver: "rstudio-server/2022.07.2-576"
+  Rserver: "rstudio-server/2022.12.0-353"
   Rapp: "r/4.2.1"
   Rspatial: "r-spatial/4.2"
   R_major_version: "4.2"

--- a/brc_rstudio-lha/template/script.sh.erb
+++ b/brc_rstudio-lha/template/script.sh.erb
@@ -47,6 +47,11 @@ EOL
 )
 chmod 700 "${RSESSION_WRAPPER_FILE}"
 
+# Create a unique $TMPDIR for runtime files
+export TMPDIR="$(mktemp -d)"
+
+echo "TMPDIR:=$(hostname):${TMPDIR}"
+
 # Generate a database.conf file
 export DBCONF="${PWD}/database.conf"
 (
@@ -54,7 +59,7 @@ umask 077
 sed 's/^ \{2\}//' > "${DBCONF}" << EOL
   # set database location
   provider=sqlite
-  directory=/tmp/rstudio-server/db
+  directory=${TMPDIR}/rstudio-server/db
 EOL
 )
 chmod 700 "${DBCONF}"
@@ -62,10 +67,6 @@ chmod 700 "${DBCONF}"
 # Set working directory to home directory
 cd "${HOME}"
 
-# Create a unique $TMPDIR for runtime files
-export TMPDIR="$(mktemp -d)"
-
-echo "TMPDIR:=n0003@testbed0:${TMPDIR}"
 
 # Output debug info
 # module list


### PR DESCRIPTION
For shared node RStudio OOD, there is a problem in that we are setting up /tmp/rstudio-server/db , but this is not specific to each user. 

This PR uses `$TMPDIR` as the location of `rstudio-server/db`.