### PR TITLE
provide different R versions to RStudio app

### DIFF
--- a/brc_rstudio-compute/form.yml.erb
+++ b/brc_rstudio-compute/form.yml.erb
@@ -25,8 +25,6 @@ cluster: "brc"
 form:
   - Rserver
   - Rapp
-  - Rspatial
-  - R_major_version
   - job_name
   - slurm_partition
   - slurm_account
@@ -40,9 +38,14 @@ form:
 
 attributes:
   Rserver: "rstudio-server/2022.12.0-353"
-  Rapp: "r/4.2.1"
-  Rspatial: "r-spatial/4.2"
-  R_major_version: "4.2"
+
+  Rapp:
+    widget: select
+    label: "R Version"
+    options:
+      - [ "4.2.1", "r/4.2.1" ]
+      - [ "4.0.3", "r/4.0.3" ]
+
 
   bc_num_hours:
     label: "Wall Clock Time"

--- a/brc_rstudio-compute/manifest.yml
+++ b/brc_rstudio-compute/manifest.yml
@@ -4,7 +4,7 @@ category: Interactive Apps
 subcategory: Servers
 role: batch_connect
 description: |
-  This app will launch an [RStudio] (an IDE for [R]) session on the Berkeley Research Computing([BRC]) Savio cluster, using R 4.2.1.
+  This app will launch an [RStudio] (an IDE for [R]) session on the Berkeley Research Computing([BRC]) Savio cluster, using R 4.2.1 (or optionally a previous version of your choice).
 
   [RStudio]: https://www.rstudio.com/products/rstudio/
   [R]: https://www.r-project.org/

--- a/brc_rstudio-compute/template/script.sh.erb
+++ b/brc_rstudio-compute/template/script.sh.erb
@@ -13,11 +13,16 @@ module load <%= context.Rserver %>
 # https://community.rstudio.com/t/rstudio-server-pro-and-r-libs-site-works-but-not-on-the-free-version-not-supported/83514
 # but when we run rsession below, we can hack it in via --r-libs-user, in addition to R_LIBS_USER
 module load r-packages
-module load <%= context.Rspatial %>   
+
+R_MAJOR_VERSION=$(echo <%= context.Rapp %> | sed -E "s/r\/([0-9]\.[0-9])\.[0-9]/\1/")
+
+echo "R_MAJOR_VERSION ${R_MAJOR_VERSION}"
+
+module load r-spatial/${R_MAJOR_VERSION}  
 
 # R_LIBS_USER will generally be empty
 if [ "$R_LIBS_USER" = "" ]; then
-    R_LIBS_USER=${HOME}/R/x86_64-pc-linux-gnu-library/<%= context.R_major_version %>
+    R_LIBS_USER=${HOME}/R/x86_64-pc-linux-gnu-library/${R_MAJOR_VERSION} 
 fi
 
 echo $R_LIBS_USER

--- a/brc_rstudio-compute/template/script.sh.erb
+++ b/brc_rstudio-compute/template/script.sh.erb
@@ -14,15 +14,15 @@ module load <%= context.Rserver %>
 # but when we run rsession below, we can hack it in via --r-libs-user, in addition to R_LIBS_USER
 module load r-packages
 
-R_MAJOR_VERSION=$(echo <%= context.Rapp %> | sed -E "s/r\/([0-9]\.[0-9])\.[0-9]/\1/")
+R_SHORT_VERSION=$(echo <%= context.Rapp %> | sed -E "s/r\/([0-9]\.[0-9])\.[0-9]/\1/")
 
-echo "R_MAJOR_VERSION ${R_MAJOR_VERSION}"
+echo "R_SHORT_VERSION ${R_SHORT_VERSION}"
 
-module load r-spatial/${R_MAJOR_VERSION}  
+module load r-spatial/${R_SHORT_VERSION}  
 
 # R_LIBS_USER will generally be empty
 if [ "$R_LIBS_USER" = "" ]; then
-    R_LIBS_USER=${HOME}/R/x86_64-pc-linux-gnu-library/${R_MAJOR_VERSION} 
+    R_LIBS_USER=${HOME}/R/x86_64-pc-linux-gnu-library/${R_SHORT_VERSION} 
 fi
 
 echo $R_LIBS_USER

--- a/brc_rstudio-lha/form.yml
+++ b/brc_rstudio-lha/form.yml
@@ -9,15 +9,17 @@ cluster: "brc_jupyter_lha"
 form:
   - Rserver
   - Rapp
-  - Rspatial
-  - R_major_version
   - bc_num_hours
 
 attributes:
   Rserver: "rstudio-server/2022.12.0-353"
-  Rapp: "r/4.2.1"
-  Rspatial: "r-spatial/4.2"
-  R_major_version: "4.2"
+
+  Rapp:
+    widget: select
+    label: "R Version"
+    options:
+      - [ "4.2.1", "r/4.2.1" ]
+      - [ "4.0.3", "r/4.0.3" ]
 
   bc_num_hours:
     label: "Wall Clock Time"

--- a/brc_rstudio-lha/manifest.yml
+++ b/brc_rstudio-lha/manifest.yml
@@ -4,7 +4,7 @@ category: Interactive Apps
 subcategory: Servers
 role: batch_connect
 description: |
-  This app will launch an [RStudio] (an IDE for [R]) session on a shared OOD node on the Berkeley Research Computing ([BRC]) Savio cluster, using R 4.2.1. Use this app to launch RStudio sessions for lightweight, short duration, interactive exploration and debugging of code and data (using a small number of cores and at most 8 GB memory). For long or compute-intensive jobs, please use the other RStudio Server app to run in the compute partitions of the Savio cluster. 
+  This app will launch an [RStudio] (an IDE for [R]) session on a shared OOD node on the Berkeley Research Computing ([BRC]) Savio cluster, using R 4.2.1 (or optionally a previous version of your choice). Use this app to launch RStudio sessions for lightweight, short duration, interactive exploration and debugging of code and data (using a small number of cores and at most 8 GB memory). For long or compute-intensive jobs, please use the other RStudio Server app to run in the compute partitions of the Savio cluster. 
 
   [RStudio]: https://www.rstudio.com/products/rstudio/
   [R]: https://www.r-project.org/

--- a/brc_rstudio-lha/template/script.sh.erb
+++ b/brc_rstudio-lha/template/script.sh.erb
@@ -12,11 +12,16 @@ module load <%= context.Rapp %>
 # https://community.rstudio.com/t/rstudio-server-pro-and-r-libs-site-works-but-not-on-the-free-version-not-supported/83514
 # but when we run rsession below, we can hack it in via --r-libs-user, in addition to R_LIBS_USER
 module load r-packages
-module load <%= context.Rspatial %>   # r-spatial/2021-02-05-r40
+
+R_MAJOR_VERSION=$(echo <%= context.Rapp %> | sed -E "s/r\/([0-9]\.[0-9])\.[0-9]/\1/")
+
+echo "R_MAJOR_VERSION ${R_MAJOR_VERSION}"
+
+module load r-spatial/${R_MAJOR_VERSION}  
 
 # R_LIBS_USER will generally be empty
 if [ "$R_LIBS_USER" = "" ]; then
-    R_LIBS_USER=${HOME}/R/x86_64-pc-linux-gnu-library/<%= context.R_major_version %>
+    R_LIBS_USER=${HOME}/R/x86_64-pc-linux-gnu-library/${R_MAJOR_VERSION}
 fi
 
 echo "R_LIBS_USER:=${R_LIBS_USER}"

--- a/brc_rstudio-lha/template/script.sh.erb
+++ b/brc_rstudio-lha/template/script.sh.erb
@@ -13,15 +13,15 @@ module load <%= context.Rapp %>
 # but when we run rsession below, we can hack it in via --r-libs-user, in addition to R_LIBS_USER
 module load r-packages
 
-R_MAJOR_VERSION=$(echo <%= context.Rapp %> | sed -E "s/r\/([0-9]\.[0-9])\.[0-9]/\1/")
+R_SHORT_VERSION=$(echo <%= context.Rapp %> | sed -E "s/r\/([0-9]\.[0-9])\.[0-9]/\1/")
 
-echo "R_MAJOR_VERSION ${R_MAJOR_VERSION}"
+echo "R_SHORT_VERSION ${R_SHORT_VERSION}"
 
-module load r-spatial/${R_MAJOR_VERSION}  
+module load r-spatial/${R_SHORT_VERSION}  
 
 # R_LIBS_USER will generally be empty
 if [ "$R_LIBS_USER" = "" ]; then
-    R_LIBS_USER=${HOME}/R/x86_64-pc-linux-gnu-library/${R_MAJOR_VERSION}
+    R_LIBS_USER=${HOME}/R/x86_64-pc-linux-gnu-library/${R_SHORT_VERSION}
 fi
 
 echo "R_LIBS_USER:=${R_LIBS_USER}"


### PR DESCRIPTION
I've added a dropdown to select r/4.2.1 or r/4.0.3. Not much to it; I did need to do a bit of configuration to use the correct r-spatial version and correct path to user-specific library tree for the version of R.

@wfeinstein when you have a chance, please take a look and merge in and deploy if looks good.