### PR TITLE
set max time 1 hr for Desktop app if using savio_debug

### DIFF
--- a/brc_desktop/form.js
+++ b/brc_desktop/form.js
@@ -100,9 +100,20 @@ function set_available_qos() {
   replace_options($("#batch_connect_session_context_qos_name"), qos);
 }
 
+function set_max_time() {
+  const selected_qos = $("#batch_connect_session_context_qos_name").val();
+  if (selected_qos === "savio_debug") {
+    $("#batch_connect_session_context_bc_num_hours").val(1);
+    $("#batch_connect_session_context_bc_num_hours").attr("max", 1);
+  } else {
+    $("#batch_connect_session_context_bc_num_hours").attr("max", "");
+  }
+}
+
 function update_available_options() {
   set_available_accounts();
   set_available_qos();
+  set_max_time();  
 }
 
 
@@ -115,6 +126,16 @@ function set_slurm_partition_change_handler() {
     toggle_gres_value_field_visibility();
     toggle_cpu_cores_field_visibility();
     toggle_slurm_account_qos_fields_visibility();
+    update_available_options();
+  });
+}
+
+/**
+ * Sets the change handler for the slurm qos select.
+ */
+function set_slurm_qos_change_handler() {
+  let slurm_qos = $("#batch_connect_session_context_qos_name");
+  slurm_qos.change(() => {
     update_available_options();
   });
 }
@@ -151,6 +172,7 @@ $(document).ready(function() {
   update_available_options();
 
   set_slurm_partition_change_handler();
+  set_slurm_qos_change_handler();
   set_slurm_account_change_handler();
 });
 

--- a/brc_desktop/form.yml.erb
+++ b/brc_desktop/form.yml.erb
@@ -43,7 +43,7 @@ attributes:
 
   bc_num_hours:
     label: "Wall Clock Time"
-    help: "The maximum number of hours your Desktop session will run for."
+    help: "The maximum number of hours your Desktop session will run for. To save FCA credits or free up resources for your condo group members, you should delete your session when you are done."
     value: 1
 
   slurm_partition: 


### PR DESCRIPTION
This addresses an oversight that we set max time of 1 hr for debug for other apps but not for Desktop.

This came up in [INC1472311](https://berkeley.service-now.com/nav_to.do?uri=incident.do%3Fsys_id=da4be03a1be8a910c4f2cb36624bcb68%26sysparm_stack=incident_list.do%3Fsysparm_query=active=true).