### PR TITLE
Fix R_LIBS_USER and clean up text shown to users.

### DIFF
--- a/brc_jupyter-interactive/manifest.yml
+++ b/brc_jupyter-interactive/manifest.yml
@@ -4,7 +4,7 @@ category: Interactive Apps
 subcategory: Servers
 role: batch_connect
 description: |
-  This app will launch a [Jupyter] server session on the Berkeley Research Computing ([BRC]) Savio cluster.
+  This app will launch a [Jupyter] server session on the Berkeley Research Computing ([BRC]) Savio cluster. On the shared node, you are limited to 8 GB memory and should use at most a few cores.
 
   [Jupyter]: https://jupyter.org/
   [Python]: https://www.python.org/

--- a/brc_rstudio-compute/manifest.yml
+++ b/brc_rstudio-compute/manifest.yml
@@ -4,7 +4,7 @@ category: Interactive Apps
 subcategory: Servers
 role: batch_connect
 description: |
-  This app will launch an [RStudio] (an IDE for [R]) session on the Berkeley Research Computing([BRC]) Savio cluster, using R 4.3.2 (or optionally a previous version of your choice).
+  This app will launch an [RStudio] (an IDE for [R]) session on the Berkeley Research Computing([BRC]) Savio cluster, using R 4.4.0.
 
   [RStudio]: https://www.rstudio.com/products/rstudio/
   [R]: https://www.r-project.org/

--- a/brc_rstudio-compute/template/script.sh.erb
+++ b/brc_rstudio-compute/template/script.sh.erb
@@ -14,18 +14,12 @@ module load <%= context.Rspatial %>
 # but when we run rsession below, we can hack it in via --r-libs-user, in addition to R_LIBS_USER
 #module load r-packages
 
-#R_SHORT_VERSION=$(echo <%= context.Rapp %> | sed -E "s/r\/([0-9]\.[0-9])\.[0-9]/\1/")
-
-#echo "R_SHORT_VERSION ${R_SHORT_VERSION}"
-
-#module load r-spatial/${R_SHORT_VERSION}  
-
 # R_LIBS_USER will generally be empty
 if [ "$R_LIBS_USER" = "" ]; then
-    R_LIBS_USER=${HOME}/R/x86_64-pc-linux-gnu-library/${R_SHORT_VERSION} 
+    R_LIBS_USER=$(Rscript -e "cat(Sys.getenv('R_LIBS_USER'))")
 fi
 
-echo $R_LIBS_USER
+echo "R_LIBS_USER is: ${R_LIBS_USER}"
 
 #
 # Start RStudio Server

--- a/brc_rstudio-interactive/form.yml.erb
+++ b/brc_rstudio-interactive/form.yml.erb
@@ -20,7 +20,7 @@ attributes:
 
   bc_num_hours:
     label: "Wall Clock Time"
-    help: "The maximum number of hours your RStudio session will run for. Pleas delete your session when you are done."
+    help: "The maximum number of hours your RStudio session will run for. Please delete your session when you are done."
     value: 1
 
   job_name:

--- a/brc_rstudio-interactive/manifest.yml
+++ b/brc_rstudio-interactive/manifest.yml
@@ -4,7 +4,7 @@ category: Interactive Apps
 subcategory: Servers
 role: batch_connect
 description: |
-  This app will launch an [RStudio] (an IDE for [R]) session on the Berkeley Research Computing([BRC]) Savio cluster, using R 4.3.2 (or optionally a previous version of your choice).
+  This app will launch an [RStudio] (an IDE for [R]) session on the Berkeley Research Computing([BRC]) Savio cluster, using R 4.4.0. On the shared node, you are limited to 8 GB memory and should use at most a few cores.
 
   [RStudio]: https://www.rstudio.com/products/rstudio/
   [R]: https://www.r-project.org/

--- a/brc_rstudio-interactive/template/script.sh.erb
+++ b/brc_rstudio-interactive/template/script.sh.erb
@@ -13,12 +13,13 @@ module load <%= context.Rspatial %>
 # https://community.rstudio.com/t/rstudio-server-pro-and-r-libs-site-works-but-not-on-the-free-version-not-supported/83514
 # but when we run rsession below, we can hack it in via --r-libs-user, in addition to R_LIBS_USER
 
+
 # R_LIBS_USER will generally be empty
 if [ "$R_LIBS_USER" = "" ]; then
-    R_LIBS_USER=${HOME}/R/x86_64-pc-linux-gnu-library/${R_SHORT_VERSION} 
+    R_LIBS_USER=$(Rscript -e "cat(Sys.getenv('R_LIBS_USER'))")
 fi
 
-echo $R_LIBS_USER
+echo "R_LIBS_USER is: ${R_LIBS_USER}"
 
 #
 # Start RStudio Server

--- a/brc_vscodeserver-interactive/manifest.yml
+++ b/brc_vscodeserver-interactive/manifest.yml
@@ -4,7 +4,7 @@ category: Interactive Apps
 subcategory: Servers
 role: batch_connect
 description: |
-  This app will launch a [VS Code] server using [Code Server] on the [UCB] [Research-IT] Berkeley Research Computing ([BRC]) Infrastructure. 
+  This app will launch a [VS Code] server using [Code Server] on the [UCB] [Research-IT] Berkeley Research Computing ([BRC]) Infrastructure. On the shared node, you are limited to 8 GB memory and should use at most a few cores.
 
   [VS Code]: https://code.visualstudio.com
   [Code Server]: https://github.com/cdr/code-server


### PR DESCRIPTION
This PR fixes how `R_LIBS_USER` is set for both of the RStudio apps.

Without that fix, users don't have direct access to packages they have installed in `~/R/x86_64-pc-linux-gnu-library/4.4`.

Also changes "4.3" to "4.4" in the forms and notes that on shared nodes only 8 GB RAM are available and to use at most a few cores.

@wfeinstein if you could prioritize getting this in, that should prevent tickets in the coming days, as we've had various users writing in about RStudio OOD issues, including this issue.