### PR TITLE
Update VSCode apps

### DIFF
--- a/brc_vscodeserver-compute/form.yml.erb
+++ b/brc_vscodeserver-compute/form.yml.erb
@@ -24,7 +24,7 @@ cluster: "brc"
 form:
   - version
   - job_name
-  - extension
+  - module
   - slurm_partition
   - slurm_account
   - qos_name
@@ -37,13 +37,13 @@ form:
 attributes:
   version: "code-server/4.91.1"
   
-  extension:
+  module:
     widget: select
-    label: "Choose an extension if needed"
-    help: "This defines the extension to load."
+    label: "Module to load (optional)"
+    help: "This defines a Savio module to load for use with VS Code."
     options:
             - [ "None", "" ]
-            - [ "Jupyter", "anaconda3/2024.02-1-11.4" ]
+            - [ "Anaconda3 (Jupyter)", "anaconda3/2024.02-1-11.4" ]
             - [ "R", "r/4.4.0-gcc-11.4.0" ]
             - [ "Julia", "julia/1.10.2-11.4" ]
 

--- a/brc_vscodeserver-compute/template/script.sh.erb
+++ b/brc_vscodeserver-compute/template/script.sh.erb
@@ -13,7 +13,7 @@ echo "$(date): Running on compute node ${compute_node}:$port"
 
 # VSCode complains that system git is too old.
 module load <%= context.version  %>
-module load <%= context.extension %>
+module load <%= context.module %>
 #
 # Start Code Server.
 #

--- a/brc_vscodeserver-interactive/form.yml
+++ b/brc_vscodeserver-interactive/form.yml
@@ -10,6 +10,7 @@ cacheable: "false"
 
 form:
   - version
+  - module
   - bc_num_hours
   - job_name
 
@@ -17,11 +18,22 @@ attributes:
 
   version: "code-server/4.91.1"
 
+  module:
+    widget: select
+    label: "Module to load (optional)"
+    help: "This defines a Savio module to load for use with VS Code."
+    options:
+            - [ "None", "" ]
+            - [ "Anaconda3 (Jupyter)", "anaconda3/2024.02-1-11.4" ]
+            - [ "R", "r/4.4.0-gcc-11.4.0" ]
+            - [ "Julia", "julia/1.10.2-11.4" ]
+            
   bc_num_hours:
     label: "Wall Clock Time"
     help: "How many hours do you want to run this VS Code Server for ?"
     value: 1
     max: 72
+    
   job_name:
     label: "Name of the job"
     value: "CodeServer_interactive"

--- a/brc_vscodeserver-interactive/template/script.sh.erb
+++ b/brc_vscodeserver-interactive/template/script.sh.erb
@@ -13,7 +13,7 @@ echo "$(date): Running on compute node ${compute_node}:$port"
 
 # VSCode complains that system git is too old.
 module load <%= context.version  %>
-#code_server_version %>
+module load <%= context.module %>
 #
 # Start Code Server.
 #


### PR DESCRIPTION
This PR does the following for the VS Code apps:

1. Add ability to load module to the shared node app as we already have for the Slurm-based app.
2. Use the term 'module' not 'extension' since we are not loading VS Code extensions.
3. Rename "Jupyter" to "Anaconda3 (Jupyter)" to make more clear which module will be loaded.