### PR TITLE
Allow user of VSCode app to load arbitrary module(s)

### DIFF
--- a/brc_vscodeserver-compute/form.yml.erb
+++ b/brc_vscodeserver-compute/form.yml.erb
@@ -24,7 +24,7 @@ cluster: "brc"
 form:
   - version
   - job_name
-  - extension
+  - modules
   - slurm_partition
   - slurm_account
   - qos_name
@@ -37,19 +37,13 @@ form:
 attributes:
   version: "code-server/4.91.1"
   
-  extension:
-    widget: select
-    label: "Choose an extension if needed"
-    help: "This defines the extension to load."
-    options:
-            - [ "None", "" ]
-            - [ "Jupyter", "anaconda3/2024.02-1-11.4" ]
-            - [ "R", "r/4.4.0-gcc-11.4.0" ]
-            - [ "Julia", "julia/1.10.2-11.4" ]
-
   job_name:
     label: "Name of the Job"
     value: "vscode_compute"
+
+  modules:
+    label: "Software modules"
+    help: "List Savio software module(s) to load for use with VS Code, separated by spaces. Version numbers are optional."
 
   bc_num_hours:
     label: "Wall Clock Time"

--- a/brc_vscodeserver-compute/form.yml.erb
+++ b/brc_vscodeserver-compute/form.yml.erb
@@ -43,7 +43,7 @@ attributes:
 
   modules:
     label: "Software modules"
-    help: "List Savio software module(s) to load for use with VS Code, separated by spaces. Version numbers are optional. To use Jupyter notebooks with VS Code, include `anaconda3` here."
+    help: "List Savio software module(s) to load for use with VS Code, separated by spaces, without quotes. Version numbers are optional. To use Jupyter notebooks with VS Code, include 'anaconda3' here."
 
   bc_num_hours:
     label: "Wall Clock Time"

--- a/brc_vscodeserver-compute/form.yml.erb
+++ b/brc_vscodeserver-compute/form.yml.erb
@@ -43,7 +43,7 @@ attributes:
 
   modules:
     label: "Software modules"
-    help: "List Savio software module(s) to load for use with VS Code, separated by spaces. Version numbers are optional."
+    help: "List Savio software module(s) to load for use with VS Code, separated by spaces. Version numbers are optional. To use Jupyter notebooks with VS Code, include `anaconda3` here."
 
   bc_num_hours:
     label: "Wall Clock Time"

--- a/brc_vscodeserver-compute/template/script.sh.erb
+++ b/brc_vscodeserver-compute/template/script.sh.erb
@@ -13,7 +13,9 @@ echo "$(date): Running on compute node ${compute_node}:$port"
 
 # VSCode complains that system git is too old.
 module load <%= context.version  %>
-module load <%= context.extension %>
+
+# User-specified module(s).
+module load <%= context.modules %>
 #
 # Start Code Server.
 #


### PR DESCRIPTION
This modifies how VS Code app handles need for users to load modules.

Instead of giving a list of potential modules of which the user can only select one, it allows the user to load what they want.

**This is not intended for merging immediately but for discussion as proof of concept.
I imagine we would add similar functionality to all the OOD apps.**

E.g., we had a user who needs to load the `imagemagick` module in order to use the R package `magick` in RStudio. They are currently loading their module in their `.bashrc`, which affects all their logins. This would allow per-session control over modules in an app.

@wfeinstein @Sapanasoni what do you think?