### PR TITLE
Remove no-longer-available --daemon flag to xfwm4 in Desktop/MATLAB apps

### DIFF
--- a/brc_desktop/template/script.sh.erb
+++ b/brc_desktop/template/script.sh.erb
@@ -13,7 +13,7 @@ cd "${HOME}"
   export XDG_DATA_HOME="<%= session.staged_root.join("share") %>"
   export XDG_CACHE_HOME="$(mktemp -d)"
   set -x
-  xfwm4 --compositor=off --daemon --sm-client-disable
+  xfwm4 --compositor=off --sm-client-disable
   xsetroot -solid "#D3D3D3"
   xfsettingsd --sm-client-disable
   xfce4-panel --sm-client-disable

--- a/brc_matlab/template/script.sh.erb
+++ b/brc_matlab/template/script.sh.erb
@@ -18,7 +18,7 @@ cd "${HOME}"
   export XDG_DATA_HOME="<%= session.staged_root.join("share") %>"
   export XDG_CACHE_HOME="$(mktemp -d)"
   set -x
-  xfwm4 --compositor=off --daemon --sm-client-disable
+  xfwm4 --compositor=off --sm-client-disable
   xsetroot -solid "#D3D3D3"
   xfsettingsd --sm-client-disable
   xfce4-panel --sm-client-disable


### PR DESCRIPTION
Per my post [here](https://github.com/OSC/bc_osc_matlab/issues/31), the `--daemon` flag no longer exists for `xfmw4`. This is causing the MATLAB app to not handle the MATLAB GUI window correctly (as discussed in [this ticket](https://berkeley.service-now.com/nav_to.do?uri=incident.do%3Fsys_id=63d1c6c9833c96d4ea5cfa547daad3fa%26sysparm_stack=incident_list.do%3Fsysparm_query=active=true)). 

This PR simply removes the flag. This seems to fix the MATLAB problem.

Strangely, even with the flag, and with `xfwm4` seemingly not starting in OOD Desktop, things look fine there. But since the flag doesn't exist, it seems correct to remove it from OOD Desktop too.

@wfeinstein given the MATLAB app is somewhat broken, if you could prioritize this that would be helpful.

