### PR TITLE
Set Jupyter apps --notebook-dir to user HOME.

### DIFF
--- a/brc_jupyter-compute/form.yml.erb
+++ b/brc_jupyter-compute/form.yml.erb
@@ -38,7 +38,7 @@ form:
 attributes:
   modules: "anaconda3/2024.02-1-11.4"
  # extra_jupyter_args: '--notebook-dir=/ --NotebookApp.default_url=/tree/global/home/users/"${USER}"'
-  extra_jupyterlab_args: '--notebook-dir=/ --NotebookApp.default_url=/global/home/users/"${USER}"'    
+  extra_jupyterlab_args: '--notebook-dir=/global/home/users/"${USER}" --NotebookApp.default_url=/global/home/users/"${USER}"'    
   
   bc_num_hours:
     label: "Wall Clock Time"

--- a/brc_jupyter-interactive/form.yml.erb
+++ b/brc_jupyter-interactive/form.yml.erb
@@ -15,7 +15,7 @@ form:
 
 attributes:
   modules: "anaconda3/2024.02-1-11.4"
-  extra_jupyterlab_args: '--notebook-dir=/ --NotebookApp.default_url=/global/home/users/"${USER}"'
+  extra_jupyterlab_args: '--notebook-dir=/global/home/users/"${USER}" --NotebookApp.default_url=/global/home/users/"${USER}"'
 
   bc_num_hours:
     label: "Wall Clock Time"


### PR DESCRIPTION
Currently in `form.yml.erb`, we have `--notebook-dir=/`, which is causing the default dir to be the filesystem root.

I think the use of `/` happens if a user ends a Jupyter OOD session via deleting the app via OOD rather than `File -> Shutdown` in the Jupyter session. If the user uses `File -> Shutdown` then I think that their current working directory is cached and re-used in the later session. 

This prevents issues like [this ticket](https://berkeley.service-now.com/nav_to.do?uri=incident.do%3Fsys_id=be2ce25593ed1a109e6afe947aba100a%26sysparm_stack=incident_list.do%3Fsysparm_query=active=true) where a user can't create a notebook without manually pointing and clicking to change the directory in the file manager pane.
