### PR TITLE
Modify Desktop app script to fix windowing issues

### DIFF
--- a/brc_desktop/template/script.sh.erb
+++ b/brc_desktop/template/script.sh.erb
@@ -7,17 +7,17 @@ cd "${HOME}"
 # Launch Xfce Window Manager and Panel
 #
 
-(
-  export SEND_256_COLORS_TO_REMOTE=1
-  export XDG_CONFIG_HOME="<%= session.staged_root.join("config") %>"
-  export XDG_DATA_HOME="<%= session.staged_root.join("share") %>"
-  export XDG_CACHE_HOME="$(mktemp -d)"
-  set -x
-  xfwm4 --compositor=off --sm-client-disable
-  xsetroot -solid "#D3D3D3"
-  xfsettingsd --sm-client-disable
-  xfce4-panel --sm-client-disable
-) &
+export SEND_256_COLORS_TO_REMOTE=1
+export XDG_CONFIG_HOME="<%= session.staged_root.join("config") %>"
+export XDG_DATA_HOME="<%= session.staged_root.join("share") %>"
+export XDG_CACHE_HOME="$(mktemp -d)"
+set -x
+xfwm4 --compositor=off --sm-client-disable &
+sleep 5
+xsetroot -solid "#D3D3D3"
+xfsettingsd --sm-client-disable
+xfce4-panel --sm-client-disable &
+sleep 5
 
 cd "$HOME"
 


### PR DESCRIPTION
In [this ticket](https://berkeley.service-now.com/nav_to.do?uri=incident.do%3Fsys_id=f34f1489930a9e109e6afe947aba103a%26sysparm_stack=incident_list.do%3Fsysparm_query=active=true) a user reported she couldn't resize the MATLAB window. 

I also tried OOD Desktop and a similar problem occurs there -- one can't move or resize windows. So we have a general problem for use of the Desktop app that will hinder users substantially.

This  [OOD Discourse discussion](https://discourse.openondemand.org/t/app-doesnt-have-desktop-background/2493) has some suggestions of how to modify the xwfm and xfce invocations. 

I've modified the OOD Desktop app's script.sh.erb to follow those suggestions and in my sandbox app, that fixes the windowing issues for the Desktop app.

However, similar modifications for the MATLAB app **do not** solve the problem for that app.

I propose that we make the changes in this PR to the Desktop app (and tell the user she can use MATLAB GUI through the Desktop app).

I don't have good ideas of what to do about the MATLAB app. 