### PR TITLE
Add num_nodes field to Desktop form.

### DIFF
--- a/brc_desktop/form.yml.erb
+++ b/brc_desktop/form.yml.erb
@@ -62,6 +62,11 @@ attributes:
     help: "The QoS you want run under. Most FCA users choose savio_normal. Condo users can either use their condo QoS or the low-priority QoS."
     widget: select
 
+  num_nodes:
+    label: "Number of Compute Nodes"
+    help: "The number of nodes you want for your Desktop session."
+    value: 1
+    
   num_cores:
     label: "Number of CPU Cores per Node"
     help: "The number of CPU cores you want per node for your Desktop session. See documentation for requirements when a GPU is requested."

--- a/brc_desktop/form.yml.erb
+++ b/brc_desktop/form.yml.erb
@@ -28,6 +28,7 @@ form:
   - slurm_account
   - qos_name
   - gres_value
+  - num_nodes
   - num_cores
   - bc_num_hours
   - user_email

--- a/brc_desktop/submit.yml.erb
+++ b/brc_desktop/submit.yml.erb
@@ -7,19 +7,7 @@
 # @see http://www.rubydoc.info/gems/ood_core/OodCore/BatchConnect/Template
 #
 batch_connect:
-  # We use the basic web server template for generating the job script
-  #
-  # @note Do not change this unless you know what you are doing!
-  template: "basic"
-
-  # You can override the command used to query the hostname of the compute node
-  # here
-  #
-  # @note It is **highly** recommended this be set in the global cluster
-  #   configuration file so that all apps can take advantage of it by default
-  #
-  #set_host: "host=$(hostname -A | awk '{print $2}')"
-
+  template: "vnc"
 #
 # Configure the job script submission parameters for the batch job here
 # @see http://www.rubydoc.info/gems/ood_core/OodCore/Job/Script

--- a/brc_matlab/submit.yml.erb
+++ b/brc_matlab/submit.yml.erb
@@ -3,6 +3,8 @@
 # Configure the job script submission parameters for the batch job here
 # @see http://www.rubydoc.info/gems/ood_core/OodCore/Job/Script
 #
+batch_connect:
+  template: "vnc"
 #script:
 #  queue_name: "queue1"
 #  accounting_id: "account1"


### PR DESCRIPTION
This fixes an omission in the recent change to the Desktop app to default to 1 core.

At the moment the Desktop app is failing with: `sbatch: error: "" is not a valid node count`.