### PR TITLE
Add modules field to all remaining apps

### DIFF
--- a/brc_desktop/form.yml.erb
+++ b/brc_desktop/form.yml.erb
@@ -24,7 +24,6 @@ cluster: "brc"
 form:
   - desktop
   - job_name
-  - modules
   - slurm_partition
   - slurm_account
   - qos_name
@@ -44,10 +43,6 @@ attributes:
   job_name:
     label: "Name of the Job"
     value: "OOD_Desktop"
-
-  modules:
-    label: "Software modules"
-    help: "List Savio software module(s) to load for use with your Desktop session, separated by spaces, without quotes. (Alternatively, you can instead load modules in a terminal window within your Desktop session.)"
 
   bc_num_hours:
     label: "Wall Clock Time"

--- a/brc_desktop/form.yml.erb
+++ b/brc_desktop/form.yml.erb
@@ -32,7 +32,8 @@ form:
   - bc_num_hours
   - user_email
   - raw_data
-  - node_type  
+  - node_type
+  - modules
 
 attributes:
   desktop: "xfce"
@@ -41,6 +42,10 @@ attributes:
   job_name:
     label: "Name of the Job"
     value: "OOD_Desktop"
+
+  modules:
+    label: "Software modules"
+    help: "List Savio software module(s) to load for use with your Desktop session, separated by spaces, without quotes. (Alternatively, you can instead load modules in a terminal window within your Desktop session.)
 
   bc_num_hours:
     label: "Wall Clock Time"

--- a/brc_desktop/form.yml.erb
+++ b/brc_desktop/form.yml.erb
@@ -45,7 +45,7 @@ attributes:
 
   modules:
     label: "Software modules"
-    help: "List Savio software module(s) to load for use with your Desktop session, separated by spaces, without quotes. (Alternatively, you can instead load modules in a terminal window within your Desktop session.)
+    help: "List Savio software module(s) to load for use with your Desktop session, separated by spaces, without quotes. (Alternatively, you can instead load modules in a terminal window within your Desktop session.)"
 
   bc_num_hours:
     label: "Wall Clock Time"

--- a/brc_desktop/form.yml.erb
+++ b/brc_desktop/form.yml.erb
@@ -24,6 +24,7 @@ cluster: "brc"
 form:
   - desktop
   - job_name
+  - modules
   - slurm_partition
   - slurm_account
   - qos_name
@@ -33,7 +34,7 @@ form:
   - user_email
   - raw_data
   - node_type
-  - modules
+
 
 attributes:
   desktop: "xfce"

--- a/brc_desktop/template/script.sh.erb
+++ b/brc_desktop/template/script.sh.erb
@@ -24,6 +24,9 @@ cd "$HOME"
 # Reset module environment (may require login shell for some HPC clusters)
 module purge && module restore
 
+# User-specified module(s).
+module load <%= context.modules %>
+
 # Ensure that the user's configured login shell is used
 export SHELL="$(getent passwd $USER | cut -d: -f7)"
 

--- a/brc_desktop/template/script.sh.erb
+++ b/brc_desktop/template/script.sh.erb
@@ -24,9 +24,6 @@ cd "$HOME"
 # Reset module environment (may require login shell for some HPC clusters)
 module purge && module restore
 
-# User-specified module(s).
-module load <%= context.modules %>
-
 # Ensure that the user's configured login shell is used
 export SHELL="$(getent passwd $USER | cut -d: -f7)"
 

--- a/brc_jupyter-compute/form.yml.erb
+++ b/brc_jupyter-compute/form.yml.erb
@@ -45,7 +45,7 @@ attributes:
 
   modules:
     label: "Software modules"
-    help: "List Savio software module(s) to load for use with your Jupyter session, separated by spaces, without quotes. Version numbers are optional. The `anaconda3/2024.02-1-11.4` module is loaded automatically.
+    help: "List Savio software module(s) to load for use with your Jupyter session, separated by spaces, without quotes. Version numbers are optional. The `anaconda3/2024.02-1-11.4` module is loaded automatically."
 
   bc_num_hours:
     label: "Wall Clock Time"

--- a/brc_jupyter-compute/form.yml.erb
+++ b/brc_jupyter-compute/form.yml.erb
@@ -22,8 +22,8 @@
 cluster: "brc"
 
 form:
-  - modules
   - job_name
+  - modules
   - slurm_partition
   - extra_jupyterlab_args
   - slurm_account

--- a/brc_jupyter-compute/form.yml.erb
+++ b/brc_jupyter-compute/form.yml.erb
@@ -36,18 +36,21 @@ form:
   - raw_data
 
 attributes:
-  modules: "anaconda3/2024.02-1-11.4"
  # extra_jupyter_args: '--notebook-dir=/ --NotebookApp.default_url=/tree/global/home/users/"${USER}"'
   extra_jupyterlab_args: '--notebook-dir=/ --NotebookApp.default_url=/global/home/users/"${USER}"'    
   
+  job_name:
+    label: "Name of the Job"
+    value: "OOD_Jupyter"
+
+  modules:
+    label: "Software modules"
+    help: "List Savio software module(s) to load for use with your Jupyter session, separated by spaces, without quotes. Version numbers are optional. The `anaconda3/2024.02-1-11.4` module is loaded automatically.
+
   bc_num_hours:
     label: "Wall Clock Time"
     help: "The maximum number of hours your Jupyter session will run for (at most one hour when using savio_debug QoS). To save FCA credits or free up resources for your condo group members, you should delete your session when you are done."
     value: 1
-
-  job_name:
-    label: "Name of the Job"
-    value: "OOD_Jupyter"
 
   slurm_partition:
     label: "SLURM Partition"

--- a/brc_jupyter-compute/template/script.sh.erb
+++ b/brc_jupyter-compute/template/script.sh.erb
@@ -14,7 +14,9 @@ cd "${HOME}"
 # Purge the module environment to avoid conflicts
 module purge
 
-# Load the require modules
+module load anaconda3/2024.02-1-11.4
+
+# User-specified module(s).
 module load <%= context.modules %>
 
 # List loaded modules

--- a/brc_jupyter-compute/template/script.sh.erb
+++ b/brc_jupyter-compute/template/script.sh.erb
@@ -23,6 +23,8 @@ module load <%= context.modules %>
 module list
 <%- end -%>
 
+module load anaconda3/2024.02-1-11.4
+
 # Benchmark info
 echo "TIMING - Starting jupyter at: $(date)"
 

--- a/brc_jupyter-compute/template/script.sh.erb
+++ b/brc_jupyter-compute/template/script.sh.erb
@@ -14,8 +14,6 @@ cd "${HOME}"
 # Purge the module environment to avoid conflicts
 module purge
 
-module load anaconda3/2024.02-1-11.4
-
 # User-specified module(s).
 module load <%= context.modules %>
 

--- a/brc_jupyter-interactive/form.yml.erb
+++ b/brc_jupyter-interactive/form.yml.erb
@@ -14,17 +14,20 @@ form:
   - bc_num_hours
 
 attributes:
-  modules: "anaconda3/2024.02-1-11.4"
   extra_jupyterlab_args: '--notebook-dir=/ --NotebookApp.default_url=/global/home/users/"${USER}"'
-
-  bc_num_hours:
-    label: "Wall Clock Time"
-    help: "The maximum number of hours your Jupyter session will run for. Please delete your session when you are done." 
-    value: 1
 
   job_name:
     label: "Name of the Job"
     value: "OOD_Jupyter"
+
+  modules:
+    label: "Software modules"
+    help: "List Savio software module(s) to load for use with your Jupyter session, separated by spaces, without quotes. Version numbers are optional. The `anaconda3/2024.02-1-11.4` module is loaded automatically.
+    
+  bc_num_hours:
+    label: "Wall Clock Time"
+    help: "The maximum number of hours your Jupyter session will run for. Please delete your session when you are done." 
+    value: 1
 
 #  slurm_partition:
 #    label: "SLURM Partition"

--- a/brc_jupyter-interactive/form.yml.erb
+++ b/brc_jupyter-interactive/form.yml.erb
@@ -22,7 +22,7 @@ attributes:
 
   modules:
     label: "Software modules"
-    help: "List Savio software module(s) to load for use with your Jupyter session, separated by spaces, without quotes. Version numbers are optional. The `anaconda3/2024.02-1-11.4` module is loaded automatically.
+    help: "List Savio software module(s) to load for use with your Jupyter session, separated by spaces, without quotes. Version numbers are optional. The `anaconda3/2024.02-1-11.4` module is loaded automatically."
     
   bc_num_hours:
     label: "Wall Clock Time"

--- a/brc_jupyter-interactive/form.yml.erb
+++ b/brc_jupyter-interactive/form.yml.erb
@@ -8,8 +8,8 @@
 cluster: "brc"
 cacheable: "false"
 form:
-  - modules
   - job_name
+  - modules
   - extra_jupyterlab_args
   - bc_num_hours
 

--- a/brc_jupyter-interactive/template/script.sh.erb
+++ b/brc_jupyter-interactive/template/script.sh.erb
@@ -14,7 +14,9 @@ cd "${HOME}"
 # Purge the module environment to avoid conflicts
 module purge
 
-# Load the require modules
+module load anaconda3/2024.02-1-11.4
+
+# User-specified module(s).
 module load <%= context.modules %>
 
 # List loaded modules

--- a/brc_jupyter-interactive/template/script.sh.erb
+++ b/brc_jupyter-interactive/template/script.sh.erb
@@ -14,14 +14,14 @@ cd "${HOME}"
 # Purge the module environment to avoid conflicts
 module purge
 
-module load anaconda3/2024.02-1-11.4
-
 # User-specified module(s).
 module load <%= context.modules %>
 
 # List loaded modules
 module list
 <%- end -%>
+
+module load anaconda3/2024.02-1-11.4
 
 # Benchmark info
 echo "TIMING - Starting jupyter at: $(date)"

--- a/brc_matlab/form.yml.erb
+++ b/brc_matlab/form.yml.erb
@@ -24,6 +24,7 @@ cluster: "brc"
 form:
   - versions
   - job_name
+  - modules
   - slurm_partition
   - slurm_account
   - qos_name
@@ -33,7 +34,7 @@ form:
   - user_email
   - raw_data
   - node_type
-  - modules
+
 
 attributes:
 

--- a/brc_matlab/form.yml.erb
+++ b/brc_matlab/form.yml.erb
@@ -46,7 +46,7 @@ attributes:
 
   modules:
     label: "Software modules"
-    help: "List Savio software module(s) to load for use with MATLAB, separated by spaces, without quotes. Version numbers are optional. 
+    help: "List Savio software module(s) to load for use with MATLAB, separated by spaces, without quotes. Version numbers are optional."
     
   versions:
     widget: select

--- a/brc_matlab/form.yml.erb
+++ b/brc_matlab/form.yml.erb
@@ -33,6 +33,7 @@ form:
   - user_email
   - raw_data
   - node_type
+  - modules
 
 attributes:
 
@@ -43,6 +44,10 @@ attributes:
     label: "Name of the Job"
     value: "OOD_MATLAB"
 
+  modules:
+    label: "Software modules"
+    help: "List Savio software module(s) to load for use with MATLAB, separated by spaces, without quotes. Version numbers are optional. 
+    
   versions:
     widget: select
     label: "MATLAB Versions"

--- a/brc_matlab/template/script.sh.erb
+++ b/brc_matlab/template/script.sh.erb
@@ -31,6 +31,9 @@ cd "$HOME"
 # Load the required environment
 module load <%= context.versions %> 
 
+# User-specified module(s).
+module load <%= context.modules %>
+
 # Launch MATLAB
 <%- if context.node_type.include?("GPU") -%>
 module list

--- a/brc_rstudio-compute/form.yml.erb
+++ b/brc_rstudio-compute/form.yml.erb
@@ -49,7 +49,7 @@ attributes:
 
   modules:
     label: "Software modules"
-    help: "List Savio software module(s) to load for use with RStudio, separated by spaces, without quotes. Version numbers are optional. 
+    help: "List Savio software module(s) to load for use with RStudio, separated by spaces, without quotes. Version numbers are optional."
 
   bc_num_hours:
     label: "Wall Clock Time"

--- a/brc_rstudio-compute/form.yml.erb
+++ b/brc_rstudio-compute/form.yml.erb
@@ -27,6 +27,7 @@ form:
   - Rapp
   - Rspatial
   - job_name
+  - modules
   - slurm_partition
   - slurm_account
   - qos_name
@@ -36,7 +37,6 @@ form:
   - bc_num_hours
   - user_email
   - raw_data
-  - modules
 
 attributes:
   Rserver: "rstudio-server/2024.04.2-764"

--- a/brc_rstudio-compute/form.yml.erb
+++ b/brc_rstudio-compute/form.yml.erb
@@ -36,21 +36,25 @@ form:
   - bc_num_hours
   - user_email
   - raw_data
+  - modules
 
 attributes:
   Rserver: "rstudio-server/2024.04.2-764"
   Rapp: "r/4.4.0-gcc-11.4.0"
   Rspatial: "r-spatial/4.4.0"
 
+  job_name:
+    label: "Name of the Job"
+    value: "OOD_RStudio"
+
+  modules:
+    label: "Software modules"
+    help: "List Savio software module(s) to load for use with RStudio, separated by spaces, without quotes. Version numbers are optional. 
 
   bc_num_hours:
     label: "Wall Clock Time"
     help: "The maximum number of hours your RStudio session will run for (at most one hour when using savio_debug QoS). To save FCA credits or free up resources for your condo group members, you should delete your session when you are done."
     value: 1
-
-  job_name:
-    label: "Name of the Job"
-    value: "OOD_RStudio"
 
   slurm_partition:
     label: "SLURM Partition"

--- a/brc_rstudio-compute/template/script.sh.erb
+++ b/brc_rstudio-compute/template/script.sh.erb
@@ -9,6 +9,9 @@ module load <%= context.Rapp %>
 module load <%= context.Rserver %>  
 module load <%= context.Rspatial %>
 
+# User-specified module(s).
+module load <%= context.modules %>
+
 # Free RStudio Server does not support use of R_LIBS_SITE:
 # https://community.rstudio.com/t/rstudio-server-pro-and-r-libs-site-works-but-not-on-the-free-version-not-supported/83514
 # but when we run rsession below, we can hack it in via --r-libs-user, in addition to R_LIBS_USER

--- a/brc_rstudio-compute/template/script.sh.erb
+++ b/brc_rstudio-compute/template/script.sh.erb
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 
+<%- unless context.modules.blank? -%>
+# Purge the module environment to avoid conflicts
 module purge
+
+# User-specified module(s).
+module load <%= context.modules %>
+
+# List loaded modules
+module list
+<%- end -%>
 
 # load R (before RStudio as RStudio module needs ${R_DIR} set)
 module load <%= context.Rapp %>  

--- a/brc_rstudio-interactive/form.yml.erb
+++ b/brc_rstudio-interactive/form.yml.erb
@@ -12,18 +12,24 @@ form:
   - job_name
   - bc_num_hours
   - Rspatial
+  - modules
 
 attributes:
   Rserver: "rstudio-server/2024.04.2-764"
   Rapp: "r/4.4.0-gcc-11.4.0"
   Rspatial: "r-spatial/4.4.0"
 
+  job_name:
+    label: "Name of the Job"
+    value: "OOD_RStudio"
+    
+  modules:
+    label: "Software modules"
+    help: "List Savio software module(s) to load for use with RStudio, separated by spaces, without quotes. Version numbers are optional. 
+    
   bc_num_hours:
     label: "Wall Clock Time"
     help: "The maximum number of hours your RStudio session will run for. Please delete your session when you are done."
     value: 1
 
-  job_name:
-    label: "Name of the Job"
-    value: "OOD_RStudio"
 

--- a/brc_rstudio-interactive/form.yml.erb
+++ b/brc_rstudio-interactive/form.yml.erb
@@ -9,10 +9,12 @@ cluster: "brc"
 form:
   - Rserver
   - Rapp
-  - job_name
-  - bc_num_hours
   - Rspatial
+  - job_name
   - modules
+  - bc_num_hours
+
+
 
 attributes:
   Rserver: "rstudio-server/2024.04.2-764"

--- a/brc_rstudio-interactive/form.yml.erb
+++ b/brc_rstudio-interactive/form.yml.erb
@@ -25,7 +25,7 @@ attributes:
     
   modules:
     label: "Software modules"
-    help: "List Savio software module(s) to load for use with RStudio, separated by spaces, without quotes. Version numbers are optional. 
+    help: "List Savio software module(s) to load for use with RStudio, separated by spaces, without quotes. Version numbers are optional."
     
   bc_num_hours:
     label: "Wall Clock Time"

--- a/brc_rstudio-interactive/template/script.sh.erb
+++ b/brc_rstudio-interactive/template/script.sh.erb
@@ -9,6 +9,11 @@ module load <%= context.Rapp %>
 module load <%= context.Rserver %>  
 
 module load <%= context.Rspatial %>
+
+# User-specified module(s).
+module load <%= context.modules %>
+
+
 # Free RStudio Server does not support use of R_LIBS_SITE:
 # https://community.rstudio.com/t/rstudio-server-pro-and-r-libs-site-works-but-not-on-the-free-version-not-supported/83514
 # but when we run rsession below, we can hack it in via --r-libs-user, in addition to R_LIBS_USER

--- a/brc_rstudio-interactive/template/script.sh.erb
+++ b/brc_rstudio-interactive/template/script.sh.erb
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 
+<%- unless context.modules.blank? -%>
+# Purge the module environment to avoid conflicts
 module purge
+
+# User-specified module(s).
+module load <%= context.modules %>
+
+# List loaded modules
+module list
+<%- end -%>
+
 
 # load R (before RStudio as RStudio module needs ${R_DIR} set)
 module load <%= context.Rapp %>  
@@ -9,9 +19,6 @@ module load <%= context.Rapp %>
 module load <%= context.Rserver %>  
 
 module load <%= context.Rspatial %>
-
-# User-specified module(s).
-module load <%= context.modules %>
 
 
 # Free RStudio Server does not support use of R_LIBS_SITE:

--- a/brc_vscodeserver-compute/template/script.sh.erb
+++ b/brc_vscodeserver-compute/template/script.sh.erb
@@ -14,8 +14,20 @@ echo "$(date): Running on compute node ${compute_node}:$port"
 # VSCode complains that system git is too old.
 module load <%= context.version  %>
 
+<%- unless context.modules.blank? -%>
+# Purge the module environment to avoid conflicts
+module purge
+
+# VSCode complains that system git is too old.
+module load <%= context.version  %>
+
 # User-specified module(s).
 module load <%= context.modules %>
+
+# List loaded modules
+module list
+<%- end -%>
+
 #
 # Start Code Server.
 #

--- a/brc_vscodeserver-interactive/form.yml
+++ b/brc_vscodeserver-interactive/form.yml
@@ -12,17 +12,23 @@ form:
   - version
   - bc_num_hours
   - job_name
+  - modules
 
 attributes:
 
   version: "code-server/4.91.1"
+
+  job_name:
+    label: "Name of the job"
+    value: "OOD_VSCode"
+    
+  modules:
+    label: "Software modules"
+    help: "List Savio software module(s) to load for use with VS Code, separated by spaces, without quotes. Version numbers are optional. To use Jupyter notebooks with VS Code, include 'anaconda3' here."
 
   bc_num_hours:
     label: "Wall Clock Time"
     help: "The maximum number of hours your VS Code session will run for. Please delete your session when you are done."
     value: 1
     max: 72
-  job_name:
-    label: "Name of the job"
-    value: "OOD_VSCode"
 

--- a/brc_vscodeserver-interactive/form.yml
+++ b/brc_vscodeserver-interactive/form.yml
@@ -10,9 +10,9 @@ cacheable: "false"
 
 form:
   - version
-  - bc_num_hours
   - job_name
   - modules
+  - bc_num_hours
 
 attributes:
 

--- a/brc_vscodeserver-interactive/template/script.sh.erb
+++ b/brc_vscodeserver-interactive/template/script.sh.erb
@@ -14,8 +14,20 @@ echo "$(date): Running on compute node ${compute_node}:$port"
 # VSCode complains that system git is too old.
 module load <%= context.version  %>
 
+<%- unless context.modules.blank? -%>
+# Purge the module environment to avoid conflicts
+module purge
+
+# VSCode complains that system git is too old.
+module load <%= context.version  %>
+
 # User-specified module(s).
 module load <%= context.modules %>
+
+# List loaded modules
+module list
+<%- end -%>
+
 
 #code_server_version %>
 #

--- a/brc_vscodeserver-interactive/template/script.sh.erb
+++ b/brc_vscodeserver-interactive/template/script.sh.erb
@@ -13,6 +13,10 @@ echo "$(date): Running on compute node ${compute_node}:$port"
 
 # VSCode complains that system git is too old.
 module load <%= context.version  %>
+
+# User-specified module(s).
+module load <%= context.modules %>
+
 #code_server_version %>
 #
 # Start Code Server.


### PR DESCRIPTION
This adds a module field so that users can choose to load modules for use with their app.

In general I tried to have this field be just after the job name field, for consistency. So one may see a bit of reordering of the fields as well in this PR.

@wfeinstein I've tested all these modified apps and they seem to work fine.