### PR TITLE
Insert missing quotation in form.yml.erb

### DIFF
--- a/brc_vscodeserver-compute/form.yml.erb
+++ b/brc_vscodeserver-compute/form.yml.erb
@@ -67,7 +67,7 @@ attributes:
 
   num_cores:
     label: "Number of CPU Cores per Node"
-    help: "The number of CPU cores you want per node for your VS Code session. See documentation for requirements when a GPU is requested.
+    help: "The number of CPU cores you want per node for your VS Code session. See documentation for requirements when a GPU is requested."
     value: 1
 
   gres_value:


### PR DESCRIPTION
This fixes a missing quotation that crept in from a commit back in the fall.

Why this wasn't missing quotation was not present before today has a complicated history, but I believe that Wei's hot-fix in December removed this syntax error and then the syntax error was in the piled-up commits that all got put in place today with the commit that updated the vscode version. (see issue #56 related to the piled-up commits)

It's not 100% clear to me why a typo in the `form.yml.erb` prevents the app from even showing up (as opposed to causing an error when a user selects the app and the form is attempted to be displayed).  In fact when I add and remove the missing quotation from my sandbox app, the app still shows up but the form can't be displayed and an error message shows in a box at the top of the attempt to display the form. 

But since this typo is clearly a problem, let's fix it and see if it fixes the missing app. Perhaps the display of the apps varies between the sandbox and the regular OOD apps.

@wfeinstein if you could again prioritize getting this live, that would be great. I am going to merge this in immediately.