### PR TITLE
robustify starting xfwm4 in Desktop

### DIFF
--- a/brc_desktop/template/script.sh.erb
+++ b/brc_desktop/template/script.sh.erb
@@ -12,11 +12,10 @@ export XDG_CONFIG_HOME="<%= session.staged_root.join("config") %>"
 export XDG_DATA_HOME="<%= session.staged_root.join("share") %>"
 export XDG_CACHE_HOME="$(mktemp -d)"
 set -x
-sleep 5
 xfwm4 --compositor=off --sm-client-disable --replace &
 sleep 5
 xsetroot -solid "#D3D3D3"
-xfsettingsd --sm-client-disable
+xfsettingsd --daemon --sm-client-disable
 xfce4-panel --sm-client-disable &
 sleep 5
 


### PR DESCRIPTION
This is an attempt to start OOD Desktop (in particular xfwm4) in a way that prevents current problems. It's not ready to merge yet, but rather to start some discussion and for some testing.

The current problems are that users and I have noticed that (sometimes) the Desktop is almost unusable because one can't resize or move app windows. Also the borders around the windows (and around the entire Desktop) disappear.

I believe I have diagnosed as occurring because the xfwm4 window manager process dies shortly after the Desktop starts. I've noticed that very briefly (about one second) when the Desktop appears, the usual border around the Desktop is there (i.e., the top 'management' bar and the small app bar at the bottom). Then it disappears. Then when I look using `ps`, `xfwm4` is not running.

Looking at `output.log`, I see the following messages:
```
Another Window Manager (Xfwm4) is already running on screen :1.0
To replace the current window manager, try "--replace"

(xfwm4:2197088): xfwm4-WARNING **: 13:48:36.095: Could not find a screen to manage, exiting
```

Following some hints from Claude, I tried to see if xfwm4 was being started multiple times, but I didn't see any indications of that happening.

So I don't know why another xfwm4 is already running.

Ideally it would be nice to figure that out so as to come up with a robust solution. 

Even if we can't, my thought with this PR is that either sleeping before starting xfwm4 (perhaps helping if something needs to finish starting before xfwm4 can start robustly) or using `--replace` (to replace whatever problematic xfwm4 has already started) might help.