### PR TITLE
Rework Jupyter dirs/paths

### DIFF
--- a/brc_jupyter-compute/form.yml.erb
+++ b/brc_jupyter-compute/form.yml.erb
@@ -23,7 +23,6 @@ cluster: "brc"
 
 form:
   - job_name
-  - path
   - modules
   - slurm_partition
   - extra_jupyterlab_args

--- a/brc_jupyter-compute/form.yml.erb
+++ b/brc_jupyter-compute/form.yml.erb
@@ -38,15 +38,11 @@ form:
 
 attributes:
  # extra_jupyter_args: '--notebook-dir=/ --NotebookApp.default_url=/tree/global/home/users/"${USER}"'
-  extra_jupyterlab_args: '--NotebookApp.default_url=/global/home/users/"${USER}"'
+  extra_jupyterlab_args: ''
   
   job_name:
     label: "Name of the Job"
     value: "OOD_Jupyter"
-
-  path:
-    label: "Base directory"
-    help: "Directory that Jupyter will treat as its root directory and that the file browser will start in. Leave blank to default to your home directory."
 
   modules:
     label: "Software modules"

--- a/brc_jupyter-compute/template/before.sh.erb
+++ b/brc_jupyter-compute/template/before.sh.erb
@@ -52,7 +52,8 @@ c.NotebookApp.password = u'sha1:${SALT}:${PASSWORD_SHA1}'
 c.NotebookApp.base_url = '/node/${host}/${port}/'
 c.NotebookApp.open_browser = False
 c.NotebookApp.allow_origin = '*'
-c.NotebookApp.notebook_dir = '${HOME}'
+c.NotebookApp.root_dir = '/'
+c.NotebookApp.preferred_dir = '${HOME}'
 c.NotebookApp.disable_check_xsrf = True
 EOL
 )

--- a/brc_jupyter-compute/template/script.sh.erb
+++ b/brc_jupyter-compute/template/script.sh.erb
@@ -26,10 +26,7 @@ module load anaconda3/2024.02-1-11.4
 # Benchmark info
 echo "TIMING - Starting jupyter at: $(date)"
 
-path=<%= context.path %>
-if [ "${path}" == "" ]; then path=${HOME}; fi
-       
 
 # Launch the Jupyter Notebook Server
 set -x
-jupyter lab --config="${CONFIG_FILE}" --notebook-dir=${path} <%= context.extra_jupyterlab_args %>
+jupyter lab --config="${CONFIG_FILE}" <%= context.extra_jupyterlab_args %>

--- a/brc_jupyter-interactive/form.yml.erb
+++ b/brc_jupyter-interactive/form.yml.erb
@@ -14,7 +14,7 @@ form:
   - bc_num_hours
 
 attributes:
-  extra_jupyterlab_args: '--NotebookApp.default_url=/global/home/users/"${USER}"'
+  extra_jupyterlab_args: '' 
 
   job_name:
     label: "Name of the Job"

--- a/brc_jupyter-interactive/form.yml.erb
+++ b/brc_jupyter-interactive/form.yml.erb
@@ -9,7 +9,6 @@ cluster: "brc"
 cacheable: "false"
 form:
   - job_name
-  - path
   - modules
   - extra_jupyterlab_args
   - bc_num_hours
@@ -21,10 +20,6 @@ attributes:
     label: "Name of the Job"
     value: "OOD_Jupyter"
 
-  path:
-    label: "Base directory"
-    help: "Directory that Jupyter will treat as its root directory and that the file browser will start in. Leave blank to default to your home directory."
-    
   modules:
     label: "Software modules"
     help: "List Savio software module(s) to load for use with your Jupyter session, separated by spaces, without quotes. Version numbers are optional. The `anaconda3/2024.02-1-11.4` module is loaded automatically."

--- a/brc_jupyter-interactive/template/before.sh.erb
+++ b/brc_jupyter-interactive/template/before.sh.erb
@@ -52,7 +52,8 @@ c.NotebookApp.password = u'sha1:${SALT}:${PASSWORD_SHA1}'
 c.NotebookApp.base_url = '/node/${host}/${port}/'
 c.NotebookApp.open_browser = False
 c.NotebookApp.allow_origin = '*'
-c.NotebookApp.notebook_dir = '${HOME}'
+c.NotebookApp.root_dir = '/'
+c.NotebookApp.preferred_dir = '${HOME}'
 c.NotebookApp.disable_check_xsrf = True
 EOL
 )

--- a/brc_jupyter-interactive/template/script.sh.erb
+++ b/brc_jupyter-interactive/template/script.sh.erb
@@ -26,10 +26,7 @@ module load anaconda3/2024.02-1-11.4
 # Benchmark info
 echo "TIMING - Starting jupyter at: $(date)"
 
-path=<%= context.path %>
-if [ "${path}" == "" ]; then path=${HOME}; fi
-
 # Launch the Jupyter Notebook Server
 set -x
-jupyter lab  --config="${CONFIG_FILE}" --notebook-dir=${path} <%= context.extra_jupyterlab_args  %>
+jupyter lab  --config="${CONFIG_FILE}" <%= context.extra_jupyterlab_args  %>
 


### PR DESCRIPTION
This follows @saroj-lbl approach in the ollama app to handle paths/dirs in the Jupyter apps, using `root_dir` and `preferred_dir` rather than the more manual approach we are currently using.

By distinguishing `root_dir` and `preferred_dir`, it also make sense to remove the `path` field since users will start by default in $HOME but then be able to navigate wherever they want (which I think is also cached for later sessions).

Let's wait to merge and make live until I can sync up with Wei to understand why the live OOD apps are not consistent with the current main branch here.