### PR TITLE
filter out non-existing savio2_gpu from app forms

### DIFF
--- a/brc_desktop/form.yml.erb
+++ b/brc_desktop/form.yml.erb
@@ -3,7 +3,7 @@
 # @note Used to define the submitted cluster, title, description, and
 #   hard-coded/user-defined attributes that make up this Batch Connect app.
 <%-
-  cmd = "/usr/bin/sacctmgr show associations user=$USER -P -n format=partition,account,qos | grep -v ood-inter |grep -vw savio |sort |uniq"
+  cmd = "/usr/bin/sacctmgr show associations user=$USER -P -n format=partition,account,qos | grep -v ood-inter | grep -v savio2_gpu | grep -vw savio |sort |uniq"
   begin
     output, status = Open3.capture2e(cmd)
     if status.success?

--- a/brc_jupyter-compute/form.yml.erb
+++ b/brc_jupyter-compute/form.yml.erb
@@ -3,7 +3,7 @@
 # @note Used to define the submitted cluster, title, description, and
 #   hard-coded/user-defined attributes that make up this Batch Connect app.
 <%-
-  cmd = "/usr/bin/sacctmgr show associations user=$USER -P -n format=partition,account,qos | grep -v ood-inter |grep -vw savio |sort |uniq"
+  cmd = "/usr/bin/sacctmgr show associations user=$USER -P -n format=partition,account,qos | grep -v ood-inter | grep -v savio2_gpu | grep -vw savio |sort |uniq"
   begin
     output, status = Open3.capture2e(cmd)
     if status.success?

--- a/brc_matlab/form.yml.erb
+++ b/brc_matlab/form.yml.erb
@@ -3,7 +3,7 @@
 # @note Used to define the submitted cluster, title, description, and
 #   hard-coded/user-defined attributes that make up this Batch Connect app.
 <%-
-  cmd = "/usr/bin/sacctmgr show associations user=$USER -P -n format=partition,account,qos | grep -v ood-inter |grep -vw savio |sort |uniq"
+  cmd = "/usr/bin/sacctmgr show associations user=$USER -P -n format=partition,account,qos | grep -v ood-inter | grep -v savio2_gpu | grep -vw savio |sort |uniq"
   begin
     output, status = Open3.capture2e(cmd)
     if status.success?

--- a/brc_rstudio-compute/form.yml.erb
+++ b/brc_rstudio-compute/form.yml.erb
@@ -3,7 +3,7 @@
 # @note Used to define the submitted cluster, title, description, and
 #   hard-coded/user-defined attributes that make up this Batch Connect app.
 <%-
-  cmd = "/usr/bin/sacctmgr show associations user=$USER -P -n format=partition,account,qos | grep -v ood-inter |grep -vw savio |sort |uniq"
+  cmd = "/usr/bin/sacctmgr show associations user=$USER -P -n format=partition,account,qos | grep -v ood-inter | grep -v savio2_gpu | grep -vw savio |sort |uniq"
   begin
     output, status = Open3.capture2e(cmd)
     if status.success?

--- a/brc_vscodeserver-compute/form.yml.erb
+++ b/brc_vscodeserver-compute/form.yml.erb
@@ -3,7 +3,7 @@
 # @note Used to define the submitted cluster, title, description, and
 #   hard-coded/user-defined attributes that make up this Batch Connect app.
 <%-
-  cmd = "/usr/bin/sacctmgr show associations user=$USER -P -n format=partition,account,qos | grep -v ood-inter |grep -vw savio |sort |uniq"
+  cmd = "/usr/bin/sacctmgr show associations user=$USER -P -n format=partition,account,qos | grep -v ood-inter | grep -v savio2_gpu | grep -vw savio |sort |uniq"
   begin
     output, status = Open3.capture2e(cmd)
     if status.success?


### PR DESCRIPTION
Filter out `savio2_gpu` from OOD forms for jupyter-compute, matlab, rstudio-compute, vscodeserver-compute and desktop apps.