### PR TITLE
update jupyter server configs (NotebookApp -> ServerApp)

### DIFF
--- a/brc_jupyter-compute/template/before.sh.erb
+++ b/brc_jupyter-compute/template/before.sh.erb
@@ -45,15 +45,15 @@ export CONFIG_FILE="${PWD}/config.py"
 (
 umask 077
 cat > "${CONFIG_FILE}" << EOL
-c.NotebookApp.ip = '*'
-c.NotebookApp.port = ${port}
-c.NotebookApp.port_retries = 0
-c.NotebookApp.password = u'sha1:${SALT}:${PASSWORD_SHA1}'
-c.NotebookApp.base_url = '/node/${host}/${port}/'
-c.NotebookApp.open_browser = False
-c.NotebookApp.allow_origin = '*'
-c.NotebookApp.root_dir = '/'
-c.NotebookApp.preferred_dir = '${HOME}'
-c.NotebookApp.disable_check_xsrf = True
+c.ServerApp.ip = '*'
+c.ServerApp.port = ${port}
+c.ServerApp.port_retries = 0
+c.PasswordIdentityProvider.hashed_password = u'sha1:${SALT}:${PASSWORD_SHA1}'
+c.ServerApp.base_url = '/node/${host}/${port}/'
+c.ServerApp.open_browser = False
+c.ServerApp.allow_origin = '*'
+c.ServerApp.root_dir = '/'
+c.FileContentsManager.preferred_dir = '${HOME}'
+c.ServerApp.disable_check_xsrf = True
 EOL
 )

--- a/brc_jupyter-interactive/template/before.sh.erb
+++ b/brc_jupyter-interactive/template/before.sh.erb
@@ -45,15 +45,15 @@ export CONFIG_FILE="${PWD}/config.py"
 (
 umask 077
 cat > "${CONFIG_FILE}" << EOL
-c.NotebookApp.ip = '*'
-c.NotebookApp.port = ${port}
-c.NotebookApp.port_retries = 0
-c.NotebookApp.password = u'sha1:${SALT}:${PASSWORD_SHA1}'
-c.NotebookApp.base_url = '/node/${host}/${port}/'
-c.NotebookApp.open_browser = False
-c.NotebookApp.allow_origin = '*'
-c.NotebookApp.root_dir = '/'
-c.NotebookApp.preferred_dir = '${HOME}'
-c.NotebookApp.disable_check_xsrf = True
+c.ServerApp.ip = '*'
+c.ServerApp.port = ${port}
+c.ServerApp.port_retries = 0
+c.PasswordIdentityProvider.hashed_password = u'sha1:${SALT}:${PASSWORD_SHA1}'
+c.ServerApp.base_url = '/node/${host}/${port}/'
+c.ServerApp.open_browser = False
+c.ServerApp.allow_origin = '*'
+c.ServerApp.root_dir = '/'
+c.FileContentsManager.preferred_dir = '${HOME}'
+c.ServerApp.disable_check_xsrf = True
 EOL
 )


### PR DESCRIPTION
Change jupyter config in both interactive and compute apps to update the deprecated options from:

```
-c.NotebookApp.ip = '*'
-c.NotebookApp.port = ${port}
-c.NotebookApp.port_retries = 0
-c.NotebookApp.password = u'sha1:${SALT}:${PASSWORD_SHA1}'
-c.NotebookApp.base_url = '/node/${host}/${port}/'
-c.NotebookApp.open_browser = False
-c.NotebookApp.allow_origin = '*'
-c.NotebookApp.root_dir = '/'
-c.NotebookApp.preferred_dir = '${HOME}'
-c.NotebookApp.disable_check_xsrf = True
```
to
```
+c.ServerApp.ip = '*'
+c.ServerApp.port = ${port}
+c.ServerApp.port_retries = 0
+c.PasswordIdentityProvider.hashed_password = u'sha1:${SALT}:${PASSWORD_SHA1}'
+c.ServerApp.base_url = '/node/${host}/${port}/'
+c.ServerApp.open_browser = False
+c.ServerApp.allow_origin = '*'
+c.ServerApp.root_dir = '/'
+c.FileContentsManager.preferred_dir = '${HOME}'
+c.ServerApp.disable_check_xsrf = True
```

Fixes #74 