### PR TITLE
Remove stray quote in submit.yml.erb that breaks session submission on the vector partition

### DIFF
--- a/brc_desktop/submit.yml.erb
+++ b/brc_desktop/submit.yml.erb
@@ -21,7 +21,7 @@ script:
    job_name: "<%= job_name %>"
    queue_name: "<%= slurm_partition %>"
    email_on_started: true
-   <%- if slurm_partition == "vector" %>"
+   <%- if slurm_partition == "vector" %>
    qos: "vector_batch"
    <%- else %> 
    <%- if qos_name != "" %>

--- a/brc_jupyter-compute/submit.yml.erb
+++ b/brc_jupyter-compute/submit.yml.erb
@@ -33,7 +33,7 @@ script:
    job_name: "<%= job_name %>"
    queue_name: "<%= slurm_partition %>"
    email_on_started: true
-   <%- if slurm_partition == "vector" %>"
+   <%- if slurm_partition == "vector" %>
    qos: "vector_batch"
    <%- else %> 
    <%- if qos_name != "" %>

--- a/brc_matlab/submit.yml.erb
+++ b/brc_matlab/submit.yml.erb
@@ -14,7 +14,7 @@ script:
    job_name: "<%= job_name %>"
    queue_name: "<%= slurm_partition %>"
    email_on_started: true
-   <%- if slurm_partition == "vector" %>"
+   <%- if slurm_partition == "vector" %>
    qos: "vector_batch"
    <%- else %> 
    <%- if qos_name != "" %>

--- a/brc_rstudio-compute/submit.yml.erb
+++ b/brc_rstudio-compute/submit.yml.erb
@@ -33,7 +33,7 @@ script:
    job_name: "<%= job_name %>"
    queue_name: "<%= slurm_partition %>"
    email_on_started: true
-   <%- if slurm_partition == "vector" %>"
+   <%- if slurm_partition == "vector" %>
    qos: "vector_batch"
    <%- else %> 
    <%- if qos_name != "" %>

--- a/brc_vscodeserver-compute/submit.yml.erb
+++ b/brc_vscodeserver-compute/submit.yml.erb
@@ -33,7 +33,7 @@ script:
    job_name: "<%= job_name %>"
    queue_name: "<%= slurm_partition %>"
    email_on_started: true
-   <%- if slurm_partition == "vector" %>"
+   <%- if slurm_partition == "vector" %>
    qos: "vector_batch"
    <%- else %> 
    <%- if qos_name != "" %>


### PR DESCRIPTION
This PR proposes removing a stray double quote in five apps' `submit.yml.erb` that stops any session from being submitted when a user selects the `vector` partition. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/345. You can sign in with your GitHub ID to claim ownership of the project.

### What is wrong today

`brc_desktop`, `brc_jupyter-compute`, `brc_matlab`, `brc_rstudio-compute` and `brc_vscodeserver-compute` each carry this line in `submit.yml.erb`, with a trailing `"` after the closing ERB tag:

```erb
   <%- if slurm_partition == "vector" %>"
   qos: "vector_batch"
```

Since the tag closes with `%>` rather than `-%>`, that quote is literal template output, and it sits inside the `vector` branch. So whenever `slurm_partition` is `vector`, the rendered submission file gets a bare `"` line immediately before `qos: "vector_batch"` and stops being valid YAML — the session never gets submitted. The four apps that do not carry the stray quote (`brc_jupyter-interactive`, `brc_rstudio-interactive`, `brc_vscodeserver-interactive`, `brc_ray_cluster`) render fine, which is what made the difference easy to isolate. `vector` is a partition these forms deliberately support: every one of the affected apps lists it in `non_account_partition` in `form.js` and hides the account and QoS fields when it is chosen.

Reproduced on `main` at 5032734 by rendering each template the way the Dashboard does — ERB with `trim_mode: "-"`, then a YAML parse:

```
ruby -rerb -ryaml -e 'class String; def blank?; strip.empty?; end; end
class C; def initialize(h);@h=h;end; def method_missing(n,*a);@h.fetch(n.to_s,"");end; def respond_to_missing?(*);true;end; def bind;binding;end; end
Dir.glob("brc_*/submit.yml.erb").sort.each do |p|
  out = ERB.new(File.read(p), trim_mode: "-").result(C.new({"slurm_partition"=>"vector","num_cores"=>"1","num_nodes"=>"1"}).bind)
  begin; YAML.safe_load(out); puts "OK   #{p}"; rescue Psych::SyntaxError => e; puts "FAIL #{p}: #{e.message}"; end
end'
```

Output on the current tree:

```
FAIL brc_desktop/submit.yml.erb: (<unknown>): could not find expected ':' while scanning a simple key at line 24 column 1
FAIL brc_jupyter-compute/submit.yml.erb: (<unknown>): could not find expected ':' while scanning a simple key at line 36 column 1
OK   brc_jupyter-interactive/submit.yml.erb
FAIL brc_matlab/submit.yml.erb: (<unknown>): could not find expected ':' while scanning a simple key at line 17 column 1
OK   brc_ray_cluster/submit.yml.erb
FAIL brc_rstudio-compute/submit.yml.erb: (<unknown>): could not find expected ':' while scanning a simple key at line 36 column 1
OK   brc_rstudio-interactive/submit.yml.erb
FAIL brc_vscodeserver-compute/submit.yml.erb: (<unknown>): could not find expected ':' while scanning a simple key at line 36 column 1
OK   brc_vscodeserver-interactive/submit.yml.erb
```

### The change

One character per file, in the five affected apps: the line becomes `<%- if slurm_partition == "vector" %>`. Nothing else is touched.

### How it was verified

The same command on this branch prints `OK` for all nine apps, and the `vector` branch now parses to the `qos: vector_batch` setting it was always meant to produce. I ran that render-and-parse check across all nine apps against three partitions — `vector`, `savio3` and `savio2_gpu` — before and after the change: five failures before (all of them on `vector`), zero after, and nothing that parsed before regressed.

To confirm nothing changes for everyone else, I also dumped the fully rendered template text for all nine apps across the non-`vector` partitions, before and after, and diffed it: byte for byte identical. That follows from where the stray quote sits — it only ever reached the output on the `vector` branch — so this cannot affect a `savio*` submission.

The one thing I cannot check from outside your cluster is a real job submission, so the remaining verification on your side is a single Desktop or Jupyter session on `vector`, which should now submit instead of erroring out.

### How this was managed

This work was tracked on a board imported from this repository's own issues and pull requests (77 stories and 6 labels): the fix is [this story](https://eastagiletracker.com/projects/345/stories/215986), and the full board is at https://eastagiletracker.com/projects/345.

![board](https://raw.githubusercontent.com/eastagiletracker/brc_oodapps/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
