### PR TITLE
remove retired partitions savio2_gpu and savio2_1080ti from form.js

### DIFF
--- a/brc_desktop/form.js
+++ b/brc_desktop/form.js
@@ -43,7 +43,7 @@ function replace_options($select, new_options) {
 function toggle_gres_value_field_visibility() {
   let slurm_partition = $("#batch_connect_session_context_slurm_partition");
   let gpu_partitions = [
-    'savio2_gpu', 'savio2_1080ti', 'savio3_gpu', 'savio4_gpu'
+    'savio3_gpu', 'savio4_gpu'
   ];
 
   toggle_visibility_of_form_group(
@@ -57,7 +57,7 @@ function toggle_gres_value_field_visibility() {
 function toggle_cpu_cores_field_visibility() {
   let slurm_partition = $("#batch_connect_session_context_slurm_partition");
   let per_core_partitions = [
-    'savio2_htc','savio3_htc','savio4_htc','savio2_gpu','savio3_gpu','savio2_1080ti', 'savio4_gpu'
+    'savio2_htc','savio3_htc','savio4_htc','savio3_gpu','savio4_gpu'
   ];
 
   toggle_visibility_of_form_group(

--- a/brc_jupyter-compute/form.js
+++ b/brc_jupyter-compute/form.js
@@ -43,7 +43,7 @@ function replace_options($select, new_options) {
 function toggle_gres_value_field_visibility() {
   let slurm_partition = $("#batch_connect_session_context_slurm_partition");
   let gpu_partitions = [
-    'savio2_gpu', 'savio2_1080ti', 'savio3_gpu', 'savio4_gpu'
+    'savio3_gpu', 'savio4_gpu'
   ];
 
   toggle_visibility_of_form_group(
@@ -57,7 +57,7 @@ function toggle_gres_value_field_visibility() {
 function toggle_cpu_cores_field_visibility() {
   let slurm_partition = $("#batch_connect_session_context_slurm_partition");
   let per_core_partitions = [
-    'savio2_htc','savio3_htc','savio4_htc','savio2_gpu','savio3_gpu','savio2_1080ti', 'savio4_gpu'
+    'savio2_htc','savio3_htc','savio4_htc','savio3_gpu','savio4_gpu'
   ];
 
   toggle_visibility_of_form_group(

--- a/brc_matlab/form.js
+++ b/brc_matlab/form.js
@@ -43,7 +43,7 @@ function replace_options($select, new_options) {
 function toggle_gres_value_field_visibility() {
   let slurm_partition = $("#batch_connect_session_context_slurm_partition");
   let gpu_partitions = [
-    'savio2_gpu', 'savio2_1080ti', 'savio3_gpu', 'savio4_gpu'
+    'savio3_gpu', 'savio4_gpu'
   ];
 
   toggle_visibility_of_form_group(
@@ -57,7 +57,7 @@ function toggle_gres_value_field_visibility() {
 function toggle_cpu_cores_field_visibility() {
   let slurm_partition = $("#batch_connect_session_context_slurm_partition");
   let per_core_partitions = [
-    'savio2_htc','savio3_htc','savio4_htc','savio2_gpu','savio3_gpu','savio2_1080ti', 'savio4_gpu'
+    'savio2_htc','savio3_htc','savio4_htc','savio3_gpu','savio4_gpu'
   ];
 
   toggle_visibility_of_form_group(

--- a/brc_rstudio-compute/form.js
+++ b/brc_rstudio-compute/form.js
@@ -43,7 +43,7 @@ function replace_options($select, new_options) {
 function toggle_gres_value_field_visibility() {
   let slurm_partition = $("#batch_connect_session_context_slurm_partition");
   let gpu_partitions = [
-    'savio2_gpu', 'savio2_1080ti', 'savio3_gpu', 'savio4_gpu'
+    'savio3_gpu', 'savio4_gpu'
   ];
 
   toggle_visibility_of_form_group(
@@ -57,7 +57,7 @@ function toggle_gres_value_field_visibility() {
 function toggle_cpu_cores_field_visibility() {
   let slurm_partition = $("#batch_connect_session_context_slurm_partition");
   let per_core_partitions = [
-    'savio3_htc','savio2_htc','savio4_htc','savio2_gpu','savio3_gpu','savio2_1080ti', 'savio4_gpu'
+    'savio3_htc','savio2_htc','savio4_htc','savio3_gpu','savio4_gpu'
   ];
 
   toggle_visibility_of_form_group(

--- a/brc_vscodeserver-compute/form.js
+++ b/brc_vscodeserver-compute/form.js
@@ -43,7 +43,7 @@ function replace_options($select, new_options) {
 function toggle_gres_value_field_visibility() {
   let slurm_partition = $("#batch_connect_session_context_slurm_partition");
   let gpu_partitions = [
-    'savio2_gpu', 'savio2_1080ti', 'savio3_gpu', 'savio4_gpu'
+    'savio3_gpu', 'savio4_gpu'
   ];
 
   toggle_visibility_of_form_group(
@@ -57,7 +57,7 @@ function toggle_gres_value_field_visibility() {
 function toggle_cpu_cores_field_visibility() {
   let slurm_partition = $("#batch_connect_session_context_slurm_partition");
   let per_core_partitions = [
-    'savio2_htc','savio3_htc','savio4_htc','savio2_gpu','savio3_gpu','savio2_1080ti', 'savio4_gpu'
+    'savio2_htc','savio3_htc','savio4_htc','savio3_gpu','savio4_gpu'
   ];
 
   toggle_visibility_of_form_group(


### PR DESCRIPTION
Remove `savio2_gpu` and `savio2_1080ti` from variables `gpu_partitions` and `per_core_partitions` from `form.js` of `desktop`, `jupyter`, `matlab`, `rstudio` and `vscodeserver` apps.

Does not change user-side behavior (good for cleaning up).