### PR TITLE
remove vector_batch qos logic from submit.yml.erb files

### DIFF
--- a/brc_desktop/submit.yml.erb
+++ b/brc_desktop/submit.yml.erb
@@ -21,12 +21,8 @@ script:
    job_name: "<%= job_name %>"
    queue_name: "<%= slurm_partition %>"
    email_on_started: true
-   <%- if slurm_partition == "vector" %>"
-   qos: "vector_batch"
-   <%- else %> 
    <%- if qos_name != "" %>
    qos: "<%= qos_name %>"
-   <%- end %>
    <%- end %>
    native:
      <%- if slurm_account != "" %>

--- a/brc_jupyter-compute/submit.yml.erb
+++ b/brc_jupyter-compute/submit.yml.erb
@@ -32,13 +32,9 @@ batch_connect:
 script:
    job_name: "<%= job_name %>"
    queue_name: "<%= slurm_partition %>"
-   email_on_started: true
-   <%- if slurm_partition == "vector" %>"
-   qos: "vector_batch"
-   <%- else %> 
+   email_on_started: true 
    <%- if qos_name != "" %>
    qos: "<%= qos_name %>"
-   <%- end %>
    <%- end %>
    native:
      <%- if slurm_account != "" %>

--- a/brc_matlab/submit.yml.erb
+++ b/brc_matlab/submit.yml.erb
@@ -14,12 +14,8 @@ script:
    job_name: "<%= job_name %>"
    queue_name: "<%= slurm_partition %>"
    email_on_started: true
-   <%- if slurm_partition == "vector" %>"
-   qos: "vector_batch"
-   <%- else %> 
    <%- if qos_name != "" %>
    qos: "<%= qos_name %>"
-   <%- end %>
    <%- end %>
    native:
      <%- if slurm_account != "" %>

--- a/brc_rstudio-compute/submit.yml.erb
+++ b/brc_rstudio-compute/submit.yml.erb
@@ -33,12 +33,8 @@ script:
    job_name: "<%= job_name %>"
    queue_name: "<%= slurm_partition %>"
    email_on_started: true
-   <%- if slurm_partition == "vector" %>"
-   qos: "vector_batch"
-   <%- else %> 
    <%- if qos_name != "" %>
    qos: "<%= qos_name %>"
-   <%- end %>
    <%- end %>
    native:
      <%- if slurm_account != "" %>

--- a/brc_vscodeserver-compute/submit.yml.erb
+++ b/brc_vscodeserver-compute/submit.yml.erb
@@ -33,12 +33,8 @@ script:
    job_name: "<%= job_name %>"
    queue_name: "<%= slurm_partition %>"
    email_on_started: true
-   <%- if slurm_partition == "vector" %>"
-   qos: "vector_batch"
-   <%- else %> 
    <%- if qos_name != "" %>
    qos: "<%= qos_name %>"
-   <%- end %>
    <%- end %>
    native:
      <%- if slurm_account != "" %>


### PR DESCRIPTION
With vector retired, we can remove the additional logic in the `submit.yml.erb` files of the compute apps.